### PR TITLE
fix: Improve NextGen metadata migration field mapping

### DIFF
--- a/includes/objects/class-image.php
+++ b/includes/objects/class-image.php
@@ -20,6 +20,7 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Objects\Image' ) ) {
             $this->migrated = false;
             $this->migrated_id = 0;
             $this->migrated_title = '';
+            $this->title = '';
             $this->caption = '';
             $this->description = '';
             $this->slug = '';
@@ -86,7 +87,7 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Objects\Image' ) ) {
             $attachment = array(
                 'ID'             => 0,
                 'guid'           => $guid,
-                'post_title'     => $this->slug,
+                'post_title'     => $this->title,
                 'post_excerpt'   => $this->caption,
                 'post_content'   => $this->description,
                 'post_date'      => $this->date,

--- a/includes/objects/class-plugin.php
+++ b/includes/objects/class-plugin.php
@@ -124,6 +124,9 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Objects\Plugin' ) ) {
             } else {
                 $image = new Image();
                 $image->source_url = $data['source_url'];
+                if ( array_key_exists( 'slug', $data ) ) {
+                    $image->slug = $data['slug'];
+                }
                 if ( array_key_exists( 'caption', $data ) ) {
                     $image->caption = $data['caption'];
                 }

--- a/includes/objects/class-plugin.php
+++ b/includes/objects/class-plugin.php
@@ -127,6 +127,9 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Objects\Plugin' ) ) {
                 if ( array_key_exists( 'slug', $data ) ) {
                     $image->slug = $data['slug'];
                 }
+                if ( array_key_exists( 'title', $data ) ) {
+                    $image->title = $data['title'];
+                }
                 if ( array_key_exists( 'caption', $data ) ) {
                     $image->caption = $data['caption'];
                 }

--- a/includes/plugins/class-nextgen.php
+++ b/includes/plugins/class-nextgen.php
@@ -163,6 +163,8 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Plugins\Nextgen' ) ) {
          * @return array
          */
         function get_gallery_settings( $gallery, $settings ) {
+            $gallery_template = $this->get_gallery_template( $gallery );
+            $settings[$gallery_template . '_caption_title_source'] = 'title';
             return $settings;
         }
 

--- a/includes/plugins/class-nextgen.php
+++ b/includes/plugins/class-nextgen.php
@@ -100,12 +100,15 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Plugins\Nextgen' ) ) {
             foreach ( $nextgen_images as $nextgen_image ) {
                 $source_url = trailingslashit( site_url() ) . trailingslashit( $gallery_path ) . $nextgen_image->filename;
 
+                // Use alttext for both title and alt, but fallback to empty string if not set
+                $alt_text = !empty($nextgen_image->alttext) ? $nextgen_image->alttext : '';
+                
                 $data = array(
                     'source_url' => $source_url,
                     'slug' => $nextgen_image->filename,
-                    'caption' => $nextgen_image->alttext,
+                    'title' => $alt_text,
+                    'alt' => $alt_text,
                     'description' => $nextgen_image->description,
-                    'alt' => '',
                     'date' => $nextgen_image->imagedate,
                     'data' => $nextgen_image
                 );

--- a/includes/plugins/class-nextgen.php
+++ b/includes/plugins/class-nextgen.php
@@ -102,8 +102,10 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Plugins\Nextgen' ) ) {
 
                 $data = array(
                     'source_url' => $source_url,
-                    'caption' => $nextgen_image->description,
-                    'alt' => $nextgen_image->alttext,
+                    'slug' => $nextgen_image->filename,
+                    'caption' => $nextgen_image->alttext,
+                    'description' => $nextgen_image->description,
+                    'alt' => '',
                     'date' => $nextgen_image->imagedate,
                     'data' => $nextgen_image
                 );

--- a/migrate.php
+++ b/migrate.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: FooGallery Migrate
 Description: Migrate to FooGallery from Envira, NextGen, Modula and other gallery plugins.
-Version:     1.3
+Version:     1.4
 Author:      FooPlugins
 Author URI:  https://fooplugins.com/
 Text Domain: foogallery-migrate
@@ -22,7 +22,7 @@ if ( ! defined( 'FOOGM_SLUG' ) ) {
     define( 'FOOGM_PATH', plugin_dir_path( __FILE__ ) );
     define( 'FOOGM_URL', plugin_dir_url( __FILE__ ) );
     define( 'FOOGM_FILE', __FILE__ );
-    define( 'FOOGM_VERSION', '1.3' );
+    define( 'FOOGM_VERSION', '1.4' );
     define( 'FOOGM_MIN_PHP', '5.4.0' ); // Minimum of PHP 5.4 required for autoloading, namespaces, etc.
     define( 'FOOGM_MIN_WP', '5.0' );  // Minimum of WordPress 5 required.
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foogallery-migrate",
   "description": "FooGallery Migrate",
-  "version": "1.3",
+  "version": "1.4",
   "author": "Brad Vincent",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: bradvin
 Tags: gallery, image gallery, photo gallery, wordpress gallery plugin, migrate
 Requires at least: 6.0
-Tested up to: 6.4
+Tested up to: 6.8
 Requires PHP: 5.4
-Stable tag: 1.3
+Stable tag: 1.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -62,6 +62,11 @@ Update now to get all the latest features, bug fixes and improvements!
 [Contact us](https://fooplugins.com/support/) and we will build an importer to help you migrate to FooGallery.
 
 == Changelog ==
+
+= 1.4 =
+* Complete NextGen metadata migration improvements
+- Fix NextGen alt text mapping to properly populate FooGallery title and alt fields
+- Configure FooGallery galleries to display image titles as caption titles
 
 = 1.3 =
 * Fixed bug where NextGen image captions were not being migrated


### PR DESCRIPTION
- Fix NextGen alt text mapping to FooGallery caption field
- Fix NextGen description mapping to FooGallery description field
- Add image slug/filename mapping for proper WordPress titles
- Update Plugin base class to handle slug field properly

Fixes metadata preservation issues during NextGen to FooGallery migration. Before: NextGen descriptions incorrectly went to captions, alt text was lost After: Proper field mapping preserves all metadata in correct FooGallery fields