### PR TITLE
Mark FooGallery Migrate tested with WordPress 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fooplugins,bradvin,elviiso
 Tags: gallery, image gallery, photo gallery, wordpress gallery plugin, migrate
 Requires at least: 6.0
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 5.4
 Stable tag: 1.7
 License: GPLv2 or later


### PR DESCRIPTION
## Summary
- update the WordPress.org `Tested up to` value from 7.0 to 7.1
- no executable plugin code, stable tag, or release artifacts changed

## Verification
- tested FooGallery Migrate 1.7.1 on WordPress 7.1-RC1 in a live sandbox
- verified the migration admin screen and all migration tabs loaded
- reran supported-source detection successfully
- saved migration settings and verified persistence/success feedback
- no supported source gallery plugin was installed, so an actual gallery import could not be exercised
- `git diff --check`
- exact one-file / one-line metadata assertion
- static secret scan
- independent review

## Release scope
Metadata only. This PR does not merge, tag, package, deploy, or publish to WordPress.org SVN.
