### PR TITLE
Migrate WordPress core galleries

### DIFF
--- a/includes/class-init.php
+++ b/includes/class-init.php
@@ -52,6 +52,9 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Init' ) ) {
             add_action( 'wp_ajax_foogallery_migrate_delete_object', array( $this, 'ajax_delete_migrated_object' ) );
 
             add_action( 'admin_post_foogallery_migrate_save_settings', array( $this, 'save_settings' ) );
+            add_action( 'admin_post_foogallery_migrate_detect_wordpress_core', array( $this, 'detect_wordpress_core_galleries' ) );
+            add_action( 'admin_post_foogallery_migrate_content', array( $this, 'migrate_content_no_js' ) );
+            add_action( 'admin_post_foogallery_migrate_refresh_content', array( $this, 'refresh_content_no_js' ) );
                       
 		}
 
@@ -97,7 +100,125 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Init' ) ) {
          * @return void
          */
         function render_view() {
+            $content_migration_result = $this->consume_content_migration_result();
             require_once 'views/view-migrate.php';
+        }
+
+        /**
+         * Consume the current administrator's no-JS content migration result.
+         *
+         * @return array|false
+         */
+        private function consume_content_migration_result() {
+            $result_key = 'foogallery_migrate_content_result_' . get_current_user_id();
+            $result = get_transient( $result_key );
+            if ( is_array( $result ) ) {
+                delete_transient( $result_key );
+                return $result;
+            }
+
+            return false;
+        }
+
+        /**
+         * Detect stored WordPress core galleries and route to content migration.
+         *
+         * Detection is read-only. Gallery creation and post updates remain behind
+         * the existing nonce/capability protected content migration action.
+         *
+         * @return void
+         */
+        function detect_wordpress_core_galleries() {
+            if ( ! current_user_can( 'manage_options' ) ) {
+                wp_die( esc_html__( 'Unauthorized.', 'foogallery-migrate' ) );
+            }
+
+            check_admin_referer( 'foogallery_migrate_detect_wordpress_core' );
+
+            $migrator = foogallery_migrate_migrator_instance();
+            $migrator->run_detection();
+            $migrator->get_gallery_migrator()->get_objects_to_migrate( true );
+            $content_items = $migrator->get_content_migrator()->scan_content( true );
+            $count = 0;
+            foreach ( $content_items as $item ) {
+                if ( is_array( $item ) && isset( $item['plugin_name'] ) && 'WordPress Core' === $item['plugin_name'] ) {
+                    $count++;
+                }
+            }
+
+            $redirect_url = add_query_arg(
+                array(
+                    'page'                       => 'foogallery-migrate',
+                    'wordpress-gallery-count'    => $count,
+                    'wordpress-gallery-detected' => $count > 0 ? '1' : '0',
+                ),
+                admin_url( 'edit.php?post_type=foogallery' )
+            );
+
+            wp_safe_redirect( $redirect_url . ( $count > 0 ? '#shortcodes' : '#sources' ) );
+            exit;
+        }
+
+        /**
+         * Migrate and replace selected content without JavaScript.
+         *
+         * @return void
+         */
+        function migrate_content_no_js() {
+            if ( ! current_user_can( 'manage_options' ) ) {
+                wp_die( esc_html__( 'Unauthorized.', 'foogallery-migrate' ) );
+            }
+
+            check_admin_referer( 'foogallery_content_migrate', 'foogallery_content_migrate' );
+
+            $selected_items = array();
+            if ( isset( $_POST['content-item'] ) ) {
+                $selected_items = map_deep( wp_unslash( $_POST['content-item'] ), 'absint' );
+            }
+
+            $result = foogallery_migrate_migrator_instance()
+                ->get_content_migrator()
+                ->migrate_and_replace_content( $selected_items );
+
+            set_transient(
+                'foogallery_migrate_content_result_' . get_current_user_id(),
+                $result,
+                MINUTE_IN_SECONDS
+            );
+
+            $this->redirect_to_content_migration();
+        }
+
+        /**
+         * Refresh the content scan without JavaScript.
+         *
+         * @return void
+         */
+        function refresh_content_no_js() {
+            if ( ! current_user_can( 'manage_options' ) ) {
+                wp_die( esc_html__( 'Unauthorized.', 'foogallery-migrate' ) );
+            }
+
+            check_admin_referer( 'foogallery_content_migrate', 'foogallery_content_migrate' );
+            $migrator = foogallery_migrate_migrator_instance();
+            $migrator->get_gallery_migrator()->get_objects_to_migrate( true );
+            $migrator->get_content_migrator()->scan_content( true );
+            $this->redirect_to_content_migration();
+        }
+
+        /**
+         * Redirect back to the content migration tab.
+         *
+         * @return void
+         */
+        private function redirect_to_content_migration() {
+            $redirect_url = add_query_arg(
+                'page',
+                'foogallery-migrate',
+                admin_url( 'edit.php?post_type=foogallery' )
+            );
+            wp_safe_redirect( $redirect_url . '#shortcodes' );
+            exit;
         }
 
         /**
@@ -399,13 +520,14 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Init' ) ) {
                     $selected_items = map_deep( wp_unslash( $_POST['content-item'] ), 'sanitize_text_field' );
                 }
 
-                $result = $content_migrator->replace_content( $selected_items );
+                $result = $content_migrator->migrate_and_replace_content( $selected_items );
 
                 // Show success/error messages
                 if ( $result['success'] > 0 ) {
                     echo '<div class="notice notice-success"><p>';
                     printf(
-                        esc_html__( 'Successfully replaced %d shortcode(s)/block(s).', 'foogallery-migrate' ),
+                        /* translators: %d: migrated occurrence count. */
+                        esc_html( _n( 'Successfully migrated and replaced %d gallery occurrence.', 'Successfully migrated and replaced %d gallery occurrences.', $result['success'], 'foogallery-migrate' ) ),
                         absint( $result['success'] )
                     );
                     echo '</p></div>';
@@ -438,6 +560,7 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Init' ) ) {
 
                 $migrator = foogallery_migrate_migrator_instance();
                 $content_migrator = $migrator->get_content_migrator();
+                $migrator->get_gallery_migrator()->get_objects_to_migrate( true );
                 $content_migrator->scan_content( true );
                 $content_migrator->render_content_form();
 

--- a/includes/class-init.php
+++ b/includes/class-init.php
@@ -141,6 +141,13 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Init' ) ) {
             check_admin_referer( 'foogallery_migrate_detect_wordpress_core' );
 
             $migrator = foogallery_migrate_migrator_instance();
+            $mode = isset( $_POST['wordpress_gallery_mode'] ) ? sanitize_key( wp_unslash( $_POST['wordpress_gallery_mode'] ) ) : '';
+            if ( ! in_array( $mode, array( Plugins\WordPressCore::MODE_CREATE, Plugins\WordPressCore::MODE_DYNAMIC ), true ) ) {
+                wp_die( esc_html__( 'Choose a valid WordPress gallery migration mode.', 'foogallery-migrate' ) );
+            }
+            if ( false === $migrator->set_migrator_setting( Plugins\WordPressCore::SETTING_MODE, $mode ) ) {
+                wp_die( esc_html__( 'The WordPress gallery migration mode could not be saved.', 'foogallery-migrate' ) );
+            }
             $migrator->run_detection();
             $migrator->get_gallery_migrator()->get_objects_to_migrate( true );
             $content_migrator = $migrator->get_content_migrator();
@@ -158,6 +165,7 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Init' ) ) {
                     'wordpress-gallery-count'    => $count,
                     'wordpress-gallery-detected' => $count > 0 ? '1' : '0',
                     'wordpress-scan-complete'    => ! empty( $progress['complete'] ) ? '1' : '0',
+                    'wordpress-gallery-mode'     => $mode,
                 ),
                 foogallery_migrate_admin_url( $count > 0 || empty( $progress['complete'] ) ? 'content' : 'sources' )
             );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -121,6 +121,7 @@ function foogallery_migrate_get_available_plugins() {
     $plugins[] = new \FooPlugins\FooGalleryMigrate\Plugins\Robo();
     $plugins[] = new \FooPlugins\FooGalleryMigrate\Plugins\Photo();
     $plugins[] = new \FooPlugins\FooGalleryMigrate\Plugins\Aigpl();
+    $plugins[] = new \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore();
 
     return $plugins;
 }

--- a/includes/migrators/class-content-migrator.php
+++ b/includes/migrators/class-content-migrator.php
@@ -163,6 +163,35 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 				}
 
 				try {
+					if ( method_exists( $plugin, 'find_content_occurrences' ) ) {
+						$occurrences = $plugin->find_content_occurrences( $post );
+						foreach ( $occurrences as $occurrence ) {
+							if ( empty( $occurrence['source_id'] ) || empty( $occurrence['original_content'] ) ) {
+								continue;
+							}
+
+							$item = $this->create_content_item(
+								$post,
+								$plugin,
+								$occurrence['source_id'],
+								$occurrence['type'],
+								$occurrence['original_content'],
+								isset( $occurrence['match_offset'] ) ? (int) $occurrence['match_offset'] : 0,
+								isset( $occurrence['block_name'] ) ? $occurrence['block_name'] : ''
+							);
+							if ( ! empty( $occurrence['source_context'] ) ) {
+								$item['source_context'] = $occurrence['source_context'];
+							}
+							if ( ! empty( $occurrence['attributes'] ) ) {
+								$item['attributes'] = $occurrence['attributes'];
+							}
+							if ( isset( $occurrence['match_offset'] ) ) {
+								$item['match_offset'] = (int) $occurrence['match_offset'];
+							}
+							$found_items[] = $item;
+						}
+					}
+
 					$block_patterns = $plugin->get_block_patterns();
 					if ( ! empty( $block_patterns ) && is_array( $block_patterns ) && ! empty( $all_blocks ) ) {
 						foreach ( $block_patterns as $block_name => $pattern ) {
@@ -239,7 +268,7 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 				'post_title' => $post->post_title,
 				'post_type' => $post->post_type,
 				'plugin_name' => $plugin->name(),
-				'gallery_id' => (int) $gallery_id,
+				'gallery_id' => is_scalar( $gallery_id ) ? (string) $gallery_id : '',
 				'object_type' => $object_type,
 				'type' => $type,
 				'original_content' => $original_content,
@@ -543,7 +572,7 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 		 */
 		private function find_migrated_object( $plugin, $gallery_id, $object_type = 'gallery' ) {
 			$migrated_objects = $this->migrator_engine->get_migrated_objects();
-			$gallery_id = (int) $gallery_id;
+			$gallery_id = (string) $gallery_id;
 			$plugin_name = $plugin->name();
 			$object_type = ( 'album' === $object_type ) ? 'album' : 'gallery';
 
@@ -561,7 +590,7 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 					continue;
 				}
 				
-				$migrated_id = isset( $migrated_object->ID ) ? (int) $migrated_object->ID : 0;
+				$migrated_id = isset( $migrated_object->ID ) ? (string) $migrated_object->ID : '';
 				
 				if ( $migrated_id !== $gallery_id ) {
 					continue;
@@ -608,9 +637,10 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 		 * Replace shortcodes/blocks in selected posts.
 		 *
 		 * @param array $selected_items Array of content item keys to replace
+		 * @param array $expected_post_contents Optional post content snapshots captured before entity migration.
 		 * @return array Results with success count and errors
 		 */
-		function replace_content( $selected_items ) {
+		function replace_content( $selected_items, $expected_post_contents = array() ) {
 			$content_items = $this->get_setting( $this->type, array() );
 			$replaced_count = 0;
 			$errors = array();
@@ -627,7 +657,7 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 
 				if ( ! $item['migrated'] || ! $item['migrated_foogallery_id'] ) {
 					$errors[] = sprintf(
-						__( '%1$s %2$d from %3$s in post "%4$s" has not been migrated yet.', 'foogallery-migrate' ),
+						__( '%1$s %2$s from %3$s in post "%4$s" has not been migrated yet.', 'foogallery-migrate' ),
 						ucfirst( $object_type ),
 						$item['gallery_id'],
 						$item['plugin_name'],
@@ -639,10 +669,18 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 				$post_id = $item['post_id'];
 				if ( ! isset( $posts_to_update[ $post_id ] ) ) {
 					$post = get_post( $post_id );
-					if ( ! $post ) {
+					if ( ! $post || 'publish' !== $post->post_status || ! in_array( $post->post_type, array( 'post', 'page' ), true ) ) {
 						$errors[] = sprintf(
-							__( 'Post %d not found.', 'foogallery-migrate' ),
+							__( 'Published post or page %d not found.', 'foogallery-migrate' ),
 							$post_id
+						);
+						continue;
+					}
+					if ( isset( $expected_post_contents[ $post_id ] ) && $post->post_content !== $expected_post_contents[ $post_id ] ) {
+						$errors[] = sprintf(
+							/* translators: %s: post title. */
+							__( 'Post or page "%s" changed during migration and was not updated. Refresh the scan and try again.', 'foogallery-migrate' ),
+							$post->post_title
 						);
 						continue;
 					}
@@ -672,14 +710,46 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 					$posts_to_update[ $post_id ]['replacements'][] = array(
 						'old' => $item['original_content'],
 						'new' => $new_content,
+						'offset' => isset( $item['match_offset'] ) ? (int) $item['match_offset'] : false,
 					);
 				}
 			}
 
 			foreach ( $posts_to_update as $post_id => $post_data ) {
 				$updated_content = $post_data['content'];
+				usort( $post_data['replacements'], array( $this, 'sort_replacements_descending' ) );
+				$applied_count = 0;
 				foreach ( $post_data['replacements'] as $replacement ) {
-					$updated_content = str_replace( $replacement['old'], $replacement['new'], $updated_content );
+					$offset = $replacement['offset'];
+					if ( false === $offset ) {
+						$offset = strpos( $updated_content, $replacement['old'] );
+					}
+
+					if ( false === $offset || substr( $updated_content, $offset, strlen( $replacement['old'] ) ) !== $replacement['old'] ) {
+						$errors[] = sprintf(
+							/* translators: %s: post title. */
+							__( 'The selected gallery occurrence in "%s" changed after detection and was not replaced. Refresh the scan and try again.', 'foogallery-migrate' ),
+							$post_data['post']->post_title
+						);
+						continue;
+					}
+
+					$updated_content = substr_replace( $updated_content, $replacement['new'], $offset, strlen( $replacement['old'] ) );
+					$applied_count++;
+				}
+
+				if ( 0 === $applied_count ) {
+					continue;
+				}
+
+				$current_post = get_post( $post_id );
+				if ( ! $current_post || 'publish' !== $current_post->post_status || ! in_array( $current_post->post_type, array( 'post', 'page' ), true ) || $current_post->post_content !== $post_data['content'] ) {
+					$errors[] = sprintf(
+						/* translators: %s: post title. */
+						__( 'Post or page "%s" changed during migration and was not updated. Refresh the scan and try again.', 'foogallery-migrate' ),
+						$post_data['post']->post_title
+					);
+					continue;
 				}
 
 				$result = wp_update_post( array(
@@ -694,7 +764,7 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 						$result->get_error_message()
 					);
 				} else {
-					$replaced_count += count( $post_data['replacements'] );
+					$replaced_count += $applied_count;
 				}
 			}
 
@@ -704,6 +774,150 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 				'success' => $replaced_count,
 				'errors' => $errors,
 			);
+		}
+
+		/**
+		 * Sort exact replacements from the end of the post to the beginning.
+		 *
+		 * @param array $left Left replacement.
+		 * @param array $right Right replacement.
+		 * @return int
+		 */
+		function sort_replacements_descending( $left, $right ) {
+			$left_offset = false === $left['offset'] ? -1 : (int) $left['offset'];
+			$right_offset = false === $right['offset'] ? -1 : (int) $right['offset'];
+			if ( $left_offset === $right_offset ) {
+				return 0;
+			}
+
+			return ( $left_offset > $right_offset ) ? -1 : 1;
+		}
+
+		/**
+		 * Migrate selected WP core gallery entities, then replace their occurrences.
+		 *
+		 * @param array $selected_items Content item keys.
+		 * @return array
+		 */
+		function migrate_and_replace_content( $selected_items ) {
+			$content_items = $this->get_setting( $this->type, array() );
+			if ( ! is_array( $content_items ) ) {
+				$content_items = array();
+			}
+			$core_source_ids = array();
+			$preflight_errors = array();
+			$preflight_post_contents = array();
+			$selected_item_keys = array_unique( array_map( 'absint', (array) $selected_items ) );
+
+			foreach ( $selected_item_keys as $item_key ) {
+				if ( ! isset( $content_items[ $item_key ] ) || ! is_array( $content_items[ $item_key ] ) ) {
+					$preflight_errors[] = __( 'One or more selected content items are no longer available. Refresh the scan and try again.', 'foogallery-migrate' );
+					continue;
+				}
+
+				$item = $content_items[ $item_key ];
+				$post = isset( $item['post_id'] ) ? get_post( $item['post_id'] ) : false;
+				$offset = isset( $item['match_offset'] ) ? (int) $item['match_offset'] : false;
+				$original_content = isset( $item['original_content'] ) ? (string) $item['original_content'] : '';
+				$is_eligible_post = $post && 'publish' === $post->post_status && in_array( $post->post_type, array( 'post', 'page' ), true );
+				if ( ! $is_eligible_post || false === $offset || '' === $original_content || substr( $post->post_content, $offset, strlen( $original_content ) ) !== $original_content ) {
+					$preflight_errors[] = sprintf(
+						/* translators: %s: post title. */
+						__( 'The selected gallery occurrence in "%s" changed after detection. Refresh the scan and try again.', 'foogallery-migrate' ),
+						isset( $item['post_title'] ) ? $item['post_title'] : ''
+					);
+					continue;
+				}
+				$preflight_post_contents[ (int) $post->ID ] = $post->post_content;
+
+				$is_core = isset( $item['plugin_name'] ) && 'WordPress Core' === $item['plugin_name'];
+				if ( $is_core && ( empty( $item['migrated'] ) || empty( $item['migrated_foogallery_id'] ) ) ) {
+					$core_source_ids[ (string) $item['gallery_id'] ] = true;
+				} elseif ( ! $is_core && ( empty( $item['migrated'] ) || empty( $item['migrated_foogallery_id'] ) ) ) {
+					$preflight_errors[] = sprintf(
+						/* translators: %s: post title. */
+						__( 'The selected gallery in "%s" has not been migrated yet.', 'foogallery-migrate' ),
+						isset( $item['post_title'] ) ? $item['post_title'] : ''
+					);
+				}
+			}
+
+			if ( ! empty( $preflight_errors ) ) {
+				return array(
+					'success' => 0,
+					'errors'  => $preflight_errors,
+				);
+			}
+
+			if ( ! empty( $core_source_ids ) ) {
+				$gallery_migrator = $this->migrator_engine->get_gallery_migrator();
+				$galleries = $gallery_migrator->get_objects_to_migrate( true );
+				$queue = array();
+				$maximum_steps = 1;
+
+				foreach ( $galleries as $gallery ) {
+					if ( 'WordPress Core' !== $gallery->plugin->name() || ! isset( $core_source_ids[ (string) $gallery->ID ] ) ) {
+						continue;
+					}
+					$queue[ $gallery->unique_identifier() ] = array(
+						'id'       => $gallery->unique_identifier(),
+						'migrated' => false,
+						'current'  => false,
+						'title'    => $gallery->title,
+					);
+					$maximum_steps += $gallery->get_children_count() + 1;
+				}
+
+				if ( count( $queue ) !== count( $core_source_ids ) ) {
+					return array(
+						'success' => 0,
+						'errors'  => array( __( 'One or more selected core galleries changed after detection. Refresh the scan and try again.', 'foogallery-migrate' ) ),
+					);
+				}
+
+				$gallery_migrator->queue_objects_for_migration( $queue );
+				for ( $step = 0; $step < $maximum_steps; $step++ ) {
+					$state = $gallery_migrator->get_state();
+					if ( is_array( $state ) && isset( $state['queued'], $state['completed'] ) && (int) $state['queued'] === (int) $state['completed'] ) {
+						break;
+					}
+					$gallery_migrator->migrate();
+				}
+
+				$state = $gallery_migrator->get_state();
+				if ( ! is_array( $state ) || empty( $state['queued'] ) || (int) $state['completed'] !== (int) $state['queued'] ) {
+					return array(
+						'success' => 0,
+						'errors'  => array( __( 'One or more core galleries could not be migrated. Review the Galleries tab for details.', 'foogallery-migrate' ) ),
+					);
+				}
+
+				$migrated_core_ids = array();
+				foreach ( $gallery_migrator->get_objects_to_migrate() as $gallery ) {
+					$source_id = isset( $gallery->ID ) ? (string) $gallery->ID : '';
+					if ( 'WordPress Core' === $gallery->plugin->name() && isset( $core_source_ids[ $source_id ] ) && ! empty( $gallery->migrated ) && ! empty( $gallery->migrated_id ) ) {
+						$migrated_core_ids[ $source_id ] = (int) $gallery->migrated_id;
+					}
+				}
+
+				if ( count( $migrated_core_ids ) !== count( $core_source_ids ) ) {
+					return array(
+						'success' => 0,
+						'errors'  => array( __( 'One or more core galleries could not be verified after migration. Review the Galleries tab for details.', 'foogallery-migrate' ) ),
+					);
+				}
+
+				foreach ( $content_items as $item_key => $item ) {
+					$source_id = is_array( $item ) && isset( $item['gallery_id'] ) ? (string) $item['gallery_id'] : '';
+					if ( isset( $migrated_core_ids[ $source_id ] ) && isset( $item['plugin_name'] ) && 'WordPress Core' === $item['plugin_name'] ) {
+						$content_items[ $item_key ]['migrated'] = true;
+						$content_items[ $item_key ]['migrated_foogallery_id'] = $migrated_core_ids[ $source_id ];
+					}
+				}
+				$this->set_setting( $this->type, $content_items );
+			}
+
+			return $this->replace_content( $selected_item_keys, $preflight_post_contents );
 		}
 
 		/**
@@ -771,6 +985,10 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 					$url = add_query_arg( 'content_paged', $page, $url ) . '#shortcodes';
 				
 					$content_items_count = count( $content_items );
+					printf(
+						'<p><strong>%s</strong></p>',
+						esc_html( sprintf( _n( '%d gallery occurrence found.', '%d gallery occurrences found.', $content_items_count, 'foogallery-migrate' ), $content_items_count ) )
+					);
 					$page_size = $this->migrator_engine->get_page_size();
 					$show_pagination = $page_size > 0;
 
@@ -806,7 +1024,8 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 					}
 					$paginated_items[ $counter ] = $item;
 					$is_migrated = ! empty( $item['migrated'] ) && ! empty( $item['migrated_foogallery_id'] );
-					if ( $is_migrated ) {
+					$is_actionable = $is_migrated || ( isset( $item['plugin_name'] ) && 'WordPress Core' === $item['plugin_name'] );
+					if ( $is_actionable ) {
 						$enabled_count++;
 						$checked_count++;
 					}
@@ -827,7 +1046,7 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 								<span><?php esc_html_e( 'Source Plugin', 'foogallery-migrate' ); ?></span>
 							</th>
 							<th scope="col" class="manage-column">
-								<span><?php esc_html_e( 'Source ID', 'foogallery-migrate' ); ?></span>
+								<span><?php esc_html_e( 'Source Context', 'foogallery-migrate' ); ?></span>
 							</th>
 							<th scope="col" class="manage-column">
 								<span><?php esc_html_e( 'Type', 'foogallery-migrate' ); ?></span>
@@ -853,10 +1072,12 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 							$foogallery_edit_link = admin_url( 'post.php?post=' . absint( $item['migrated_foogallery_id'] ) . '&action=edit' );
 						}
 						$is_migrated = ! empty( $item['migrated'] ) && ! empty( $item['migrated_foogallery_id'] );
+						$is_core = isset( $item['plugin_name'] ) && 'WordPress Core' === $item['plugin_name'];
+						$is_actionable = $is_migrated || $is_core;
 						?>
 						<tr class="<?php echo esc_attr( ($key % 2 === 0) ? 'alternate' : '' ); ?>">
 							<th scope="row" class="check-column">
-								<?php if ( $is_migrated ) { ?>
+								<?php if ( $is_actionable ) { ?>
 									<input name="content-item[]" type="checkbox" checked="checked" value="<?php echo esc_attr( $key ); ?>">
 								<?php } else { ?>
 									<input name="content-item[]" type="checkbox" disabled="disabled" value="<?php echo esc_attr( $key ); ?>">
@@ -873,7 +1094,7 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 								<?php echo esc_html( $item['plugin_name'] ); ?>
 							</td>
 							<td>
-								<?php echo esc_html( $item['gallery_id'] ); ?>
+								<?php echo esc_html( isset( $item['source_context'] ) ? $item['source_context'] : $item['gallery_id'] ); ?>
 							</td>
 							<td>
 								<?php
@@ -893,6 +1114,8 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 							<td>
 								<?php if ( $is_migrated ) { ?>
 									<span style="color: #080;"><?php esc_html_e( 'Migrated', 'foogallery-migrate' ); ?></span>
+								<?php } elseif ( $is_core ) { ?>
+									<span style="color: #2271b1;"><?php esc_html_e( 'Ready to migrate', 'foogallery-migrate' ); ?></span>
 								<?php } else { ?>
 									<span style="color: #f60;"><?php esc_html_e( 'Not Migrated', 'foogallery-migrate' ); ?></span>
 								<?php } ?>
@@ -914,9 +1137,9 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 			}
 			?>
 			<p>
-				<button name="foogallery_content_action" value="foogallery_content_replace"
-						class="button button-primary replace_content"><?php esc_html_e( 'Replace Selected', 'foogallery-migrate' ); ?></button>
-				<button name="foogallery_content_action" value="foogallery_content_refresh"
+				<button name="action" value="foogallery_migrate_content"
+						class="button button-primary replace_content"><?php esc_html_e( 'Migrate & Replace Selected', 'foogallery-migrate' ); ?></button>
+				<button name="action" value="foogallery_migrate_refresh_content"
 						class="button refresh_content"><?php esc_html_e( 'Refresh Scan', 'foogallery-migrate' ); ?></button>
 			</p>
 			<div id="foogallery_migrate_content_spinner" style="width:20px; display: inline-block;">

--- a/includes/migrators/class-content-migrator.php
+++ b/includes/migrators/class-content-migrator.php
@@ -374,6 +374,9 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 							if ( ! empty( $occurrence['attributes'] ) ) {
 								$item['attributes'] = $occurrence['attributes'];
 							}
+							if ( ! empty( $occurrence['replacement_content'] ) && is_string( $occurrence['replacement_content'] ) ) {
+								$item['replacement_content'] = $occurrence['replacement_content'];
+							}
 							if ( isset( $occurrence['match_offset'] ) ) {
 								$item['match_offset'] = (int) $occurrence['match_offset'];
 							}
@@ -1406,7 +1409,10 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 				$preflight_post_contents[ (int) $post->ID ] = $post->post_content;
 
 				$is_core = isset( $item['plugin_name'] ) && 'WordPress Core' === $item['plugin_name'];
-				if ( $is_core && ( empty( $item['migrated'] ) || empty( $item['migrated_foogallery_id'] ) ) ) {
+				$has_direct_replacement = isset( $item['replacement_content'] ) && is_string( $item['replacement_content'] ) && '' !== trim( $item['replacement_content'] );
+				if ( $has_direct_replacement ) {
+					continue;
+				} elseif ( $is_core && ( empty( $item['migrated'] ) || empty( $item['migrated_foogallery_id'] ) ) ) {
 					$core_source_ids[ (string) $item['gallery_id'] ] = true;
 				} elseif ( ! $is_core && ( empty( $item['migrated'] ) || empty( $item['migrated_foogallery_id'] ) ) ) {
 					$preflight_errors[] = sprintf(
@@ -1508,6 +1514,33 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 			$scan_paused = $has_scanned_content && ! $progress['complete'];
 
 			wp_nonce_field( 'foogallery_content_migrate', 'foogallery_content_migrate', false );
+
+			$core_dynamic_items = array_filter(
+				$content_items,
+				function( $item ) {
+					return is_array( $item )
+						&& isset( $item['plugin_name'] )
+						&& 'WordPress Core' === $item['plugin_name']
+						&& ! empty( $item['replacement_content'] );
+				}
+			);
+			$core_reusable_items = array_filter(
+				$content_items,
+				function( $item ) {
+					return is_array( $item )
+						&& isset( $item['plugin_name'] )
+						&& 'WordPress Core' === $item['plugin_name']
+						&& empty( $item['replacement_content'] );
+				}
+			);
+
+			if ( ! empty( $core_dynamic_items ) ) {
+				echo '<div class="notice notice-info inline"><p><strong>' . esc_html__( 'WordPress galleries: Dynamic replacement mode', 'foogallery-migrate' ) . '</strong><br>';
+				echo esc_html__( 'Selected occurrences will be replaced with dynamic FooGalleries. No FooGallery records will be created.', 'foogallery-migrate' ) . '</p></div>';
+			} elseif ( ! empty( $core_reusable_items ) ) {
+				echo '<div class="notice notice-info inline"><p><strong>' . esc_html__( 'WordPress galleries: Reusable FooGallery mode', 'foogallery-migrate' ) . '</strong><br>';
+				echo esc_html__( 'Selected occurrences will create editable FooGallery records before the source content is replaced.', 'foogallery-migrate' ) . '</p></div>';
+			}
 
 			if ( $scan_paused ) {
 				echo '<div class="notice notice-warning inline"><p>';
@@ -1683,10 +1716,10 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 							<td>
 								<?php if ( $is_migrated ) { ?>
 									<span style="color: #080;"><?php esc_html_e( 'Migrated', 'foogallery-migrate' ); ?></span>
+								<?php } else if ( $is_direct_replacement ) { ?>
+									<span style="color: #080;"><?php esc_html_e( 'Ready to replace', 'foogallery-migrate' ); ?></span>
 								<?php } elseif ( $is_core ) { ?>
 									<span style="color: #2271b1;"><?php esc_html_e( 'Ready to migrate', 'foogallery-migrate' ); ?></span>
-								<?php } else if ( $is_direct_replacement ) { ?>
-									<span style="color: #080;"><?php esc_html_e( 'Ready', 'foogallery-migrate' ); ?></span>
 								<?php } else { ?>
 									<span style="color: #f60;"><?php esc_html_e( 'Not Migrated', 'foogallery-migrate' ); ?></span>
 								<?php } ?>

--- a/includes/plugins/class-word-press-core.php
+++ b/includes/plugins/class-word-press-core.php
@@ -1,0 +1,511 @@
+<?php
+/**
+ * WordPress core gallery migration source.
+ *
+ * @package FooPlugins\FooGalleryMigrate
+ */
+
+namespace FooPlugins\FooGalleryMigrate\Plugins;
+
+use FooPlugins\FooGalleryMigrate\Objects\Image;
+use FooPlugins\FooGalleryMigrate\Objects\Plugin;
+
+if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Plugins\WordPressCore' ) ) {
+
+    /**
+     * Treats each stored core gallery occurrence as a migratable gallery.
+     */
+    class WordPressCore extends Plugin {
+
+        /**
+         * Source name.
+         *
+         * @return string
+         */
+        function name() {
+            return 'WordPress Core';
+        }
+
+        /**
+         * Detect at least one valid core gallery occurrence.
+         *
+         * @return bool
+         */
+        function detect() {
+            foreach ( $this->get_eligible_posts() as $post ) {
+                if ( ! empty( $this->find_content_occurrences( $post ) ) ) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /**
+         * Build one migratable gallery per stored occurrence.
+         *
+         * @return array
+         */
+        function find_galleries() {
+            $galleries = array();
+
+            foreach ( $this->get_eligible_posts() as $post ) {
+                foreach ( $this->find_content_occurrences( $post ) as $occurrence ) {
+                    $children = array();
+                    foreach ( $occurrence['attachment_ids'] as $attachment_id ) {
+                        $image = new Image();
+                        $image->source_url = wp_get_attachment_url( $attachment_id );
+                        $image->migrated_id = $attachment_id;
+                        $image->migrated = true;
+                        $children[] = $image;
+                    }
+
+                    $data = array(
+                        'ID'       => $occurrence['source_id'],
+                        'title'    => $occurrence['title'],
+                        'data'     => array(
+                            'post_id'          => (int) $post->ID,
+                            'source_context'   => $occurrence['source_context'],
+                            'attributes'       => $occurrence['attributes'],
+                            'original_content' => $occurrence['original_content'],
+                        ),
+                        'children' => $children,
+                        'settings' => $occurrence['attributes'],
+                    );
+
+                    $galleries[] = $this->get_gallery( $data );
+                }
+            }
+
+            return $galleries;
+        }
+
+        /**
+         * Core galleries do not contain albums.
+         *
+         * @return array
+         */
+        function find_albums() {
+            return array();
+        }
+
+        /**
+         * Use FooGallery's default layout unless the global override applies.
+         *
+         * @param object $gallery Gallery object.
+         * @return string
+         */
+        function get_gallery_template( $gallery ) {
+            return 'default';
+        }
+
+        /**
+         * Preserve attributes that map safely to FooGallery settings.
+         *
+         * The complete normalized source attributes also remain on the gallery
+         * migration data for audit/debug purposes.
+         *
+         * @param object $gallery Gallery object.
+         * @param array  $settings Existing settings.
+         * @return array
+         */
+        function get_gallery_settings( $gallery, $settings ) {
+            if ( ! is_array( $settings ) ) {
+                $settings = array();
+            }
+
+            $attributes = isset( $gallery->settings ) && is_array( $gallery->settings ) ? $gallery->settings : array();
+            $template = $this->get_migration_gallery_template( $gallery );
+            $link = isset( $attributes['link'] ) ? $attributes['link'] : ( isset( $attributes['linkTo'] ) ? $attributes['linkTo'] : '' );
+
+            if ( in_array( $link, array( 'file', 'media' ), true ) ) {
+                $settings[ $template . '_lightbox' ] = 'foobox';
+            } elseif ( 'none' === $link ) {
+                $settings[ $template . '_lightbox' ] = 'none';
+            }
+
+            return $settings;
+        }
+
+        /**
+         * Parse valid core gallery occurrences in a post.
+         *
+         * @param object $post WordPress post object.
+         * @return array
+         */
+        function find_content_occurrences( $post ) {
+            $occurrences = array();
+            if ( ! is_object( $post ) || empty( $post->post_content ) ) {
+                return $occurrences;
+            }
+
+            $content = (string) $post->post_content;
+            $block_ranges = array();
+            $gallery_blocks = array();
+            if ( function_exists( 'parse_blocks' ) ) {
+                $this->collect_block_occurrences( $content, $block_ranges, $gallery_blocks );
+            }
+
+            $raw_occurrences = array();
+            foreach ( $gallery_blocks as $gallery_block ) {
+                $attachment_ids = $this->get_block_attachment_ids( $gallery_block['block'] );
+                if ( empty( $attachment_ids ) ) {
+                    continue;
+                }
+
+                $raw_occurrences[] = array(
+                    'type'             => 'block',
+                    'block_name'       => 'core/gallery',
+                    'original_content' => $gallery_block['serialized'],
+                    'match_offset'     => $gallery_block['offset'],
+                    'attachment_ids'   => $attachment_ids,
+                    'attributes'       => $this->normalize_attributes( isset( $gallery_block['block']['attrs'] ) ? $gallery_block['block']['attrs'] : array() ),
+                );
+            }
+
+            if ( function_exists( 'get_shortcode_regex' ) && function_exists( 'shortcode_parse_atts' ) ) {
+                $pattern = get_shortcode_regex( array( 'gallery' ) );
+                $matches = array();
+                if ( preg_match_all( '/' . $pattern . '/s', $content, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE ) ) {
+                    foreach ( $matches as $match ) {
+                        if ( '[' === $match[1][0] || ']' === $match[6][0] ) {
+                            continue;
+                        }
+
+                        $offset = (int) $match[0][1];
+                        if ( ! $this->shortcode_is_allowed_at_offset( $offset, $block_ranges ) ) {
+                            continue;
+                        }
+
+                        $attributes = shortcode_parse_atts( $match[3][0] );
+                        $attributes = is_array( $attributes ) ? $attributes : array();
+                        $attachment_ids = $this->get_shortcode_attachment_ids( $post, $attributes );
+                        if ( empty( $attachment_ids ) ) {
+                            continue;
+                        }
+
+                        $raw_occurrences[] = array(
+                            'type'             => 'shortcode',
+                            'original_content' => $match[0][0],
+                            'match_offset'     => $offset,
+                            'attachment_ids'   => $attachment_ids,
+                            'attributes'       => $this->normalize_attributes( $attributes ),
+                        );
+                    }
+                }
+            }
+
+            usort( $raw_occurrences, array( $this, 'sort_occurrences_by_offset' ) );
+            $identity_counts = array();
+            foreach ( $raw_occurrences as $index => $occurrence ) {
+                $number = $index + 1;
+                $identity_hash = $occurrence['type'] . '-' . substr( md5( $occurrence['original_content'] ), 0, 12 );
+                $identity_counts[ $identity_hash ] = isset( $identity_counts[ $identity_hash ] ) ? $identity_counts[ $identity_hash ] + 1 : 1;
+                $source_id = (int) $post->ID . '-' . $identity_hash . '-' . $identity_counts[ $identity_hash ];
+                $type_label = 'block' === $occurrence['type'] ? __( 'Gallery block', 'foogallery-migrate' ) : __( 'Gallery shortcode', 'foogallery-migrate' );
+
+                $occurrence['source_id'] = $source_id;
+                $occurrence['title'] = sprintf(
+                    /* translators: 1: post title, 2: gallery occurrence number. */
+                    __( '%1$s - core gallery %2$d', 'foogallery-migrate' ),
+                    $post->post_title,
+                    $number
+                );
+                $occurrence['source_context'] = sprintf(
+                    /* translators: 1: source type, 2: occurrence number, 3: attachment count. */
+                    _n( '%1$s #%2$d (%3$d image)', '%1$s #%2$d (%3$d images)', count( $occurrence['attachment_ids'] ), 'foogallery-migrate' ),
+                    $type_label,
+                    $number,
+                    count( $occurrence['attachment_ids'] )
+                );
+                $occurrences[] = $occurrence;
+            }
+
+            return $occurrences;
+        }
+
+        /**
+         * Sort parsed occurrences into source order.
+         *
+         * @param array $left Left occurrence.
+         * @param array $right Right occurrence.
+         * @return int
+         */
+        function sort_occurrences_by_offset( $left, $right ) {
+            if ( $left['match_offset'] === $right['match_offset'] ) {
+                return 0;
+            }
+
+            return ( $left['match_offset'] < $right['match_offset'] ) ? -1 : 1;
+        }
+
+        /**
+         * Locate exact block source ranges without canonicalizing stored markup.
+         *
+         * @param string $content Full post content.
+         * @param array  $ranges Located block ranges.
+         * @param array  $galleries Located gallery blocks.
+         * @return void
+         */
+        private function collect_block_occurrences( $content, &$ranges, &$galleries ) {
+            $matches = array();
+            if ( ! preg_match_all( '/<!--\s*(\/?)wp:([^\s>]+)(.*?)-->/s', $content, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE ) ) {
+                return;
+            }
+
+            $stack = array();
+            foreach ( $matches as $match ) {
+                $token = $match[0][0];
+                $offset = (int) $match[0][1];
+                $is_closing = '/' === $match[1][0];
+                $name = $this->normalize_block_name( $match[2][0] );
+                $is_self_closing = ! $is_closing && preg_match( '/\/\s*$/', $match[3][0] );
+
+                if ( $is_closing ) {
+                    $last_index = count( $stack ) - 1;
+                    if ( $last_index < 0 || $stack[ $last_index ]['name'] !== $name ) {
+                        continue;
+                    }
+
+                    $opened = array_pop( $stack );
+                    $this->add_block_range(
+                        $content,
+                        $opened['start'],
+                        $offset + strlen( $token ),
+                        $name,
+                        $opened['depth'],
+                        $ranges,
+                        $galleries
+                    );
+                } elseif ( $is_self_closing ) {
+                    $this->add_block_range(
+                        $content,
+                        $offset,
+                        $offset + strlen( $token ),
+                        $name,
+                        count( $stack ),
+                        $ranges,
+                        $galleries
+                    );
+                } else {
+                    $stack[] = array(
+                        'start' => $offset,
+                        'name'  => $name,
+                        'depth' => count( $stack ),
+                    );
+                }
+            }
+        }
+
+        /**
+         * Add one exact block range and parse gallery block data.
+         *
+         * @param string $content Full post content.
+         * @param int    $start Start offset.
+         * @param int    $end End offset.
+         * @param string $name Normalized block name.
+         * @param int    $depth Nesting depth.
+         * @param array  $ranges Located block ranges.
+         * @param array  $galleries Located gallery blocks.
+         * @return void
+         */
+        private function add_block_range( $content, $start, $end, $name, $depth, &$ranges, &$galleries ) {
+            $serialized = substr( $content, $start, $end - $start );
+            $ranges[] = array(
+                'start' => $start,
+                'end'   => $end,
+                'name'  => $name,
+                'depth' => $depth,
+            );
+
+            if ( 'core/gallery' !== $name ) {
+                return;
+            }
+
+            $parsed = parse_blocks( $serialized );
+            if ( empty( $parsed ) || ! is_array( $parsed[0] ) || 'core/gallery' !== $parsed[0]['blockName'] ) {
+                return;
+            }
+
+            $galleries[] = array(
+                'block'      => $parsed[0],
+                'serialized' => $serialized,
+                'offset'     => $start,
+            );
+        }
+
+        /**
+         * Normalize parser comment names to WordPress block names.
+         *
+         * @param string $name Raw block name.
+         * @return string
+         */
+        private function normalize_block_name( $name ) {
+            return false === strpos( $name, '/' ) ? 'core/' . $name : $name;
+        }
+
+        /**
+         * Only freeform/classic content and core shortcode blocks own shortcodes.
+         *
+         * @param int   $offset Match offset.
+         * @param array $ranges Located block ranges.
+         * @return bool
+         */
+        private function shortcode_is_allowed_at_offset( $offset, $ranges ) {
+            $owner = false;
+            foreach ( $ranges as $range ) {
+                if ( $offset >= $range['start'] && $offset < $range['end'] ) {
+                    if ( false === $owner || $range['depth'] >= $owner['depth'] ) {
+                        $owner = $range;
+                    }
+                }
+            }
+
+            return false === $owner || 'core/shortcode' === $owner['name'];
+        }
+
+        /**
+         * Resolve IDs from core/gallery block attributes and nested images.
+         *
+         * @param array $block Gallery block.
+         * @return array
+         */
+        private function get_block_attachment_ids( $block ) {
+            $ids = array();
+            if ( ! empty( $block['attrs']['ids'] ) && is_array( $block['attrs']['ids'] ) ) {
+                $ids = $block['attrs']['ids'];
+            }
+
+            $nested_ids = array();
+            if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+                $this->collect_image_block_ids( $block['innerBlocks'], $nested_ids );
+            }
+            if ( ! empty( $nested_ids ) ) {
+                $ids = $nested_ids;
+            }
+
+            return $this->normalize_attachment_ids( $ids );
+        }
+
+        /**
+         * Recursively collect core/image IDs.
+         *
+         * @param array $blocks Image blocks.
+         * @param array $ids Attachment IDs.
+         * @return void
+         */
+        private function collect_image_block_ids( $blocks, &$ids ) {
+            foreach ( $blocks as $block ) {
+                if ( isset( $block['blockName'] ) && 'core/image' === $block['blockName'] && ! empty( $block['attrs']['id'] ) ) {
+                    $ids[] = $block['attrs']['id'];
+                }
+                if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+                    $this->collect_image_block_ids( $block['innerBlocks'], $ids );
+                }
+            }
+        }
+
+        /**
+         * Resolve shortcode IDs, including classic galleries without an ids attribute.
+         *
+         * @param object $post Post object.
+         * @param array  $attributes Parsed shortcode attributes.
+         * @return array
+         */
+        private function get_shortcode_attachment_ids( $post, $attributes ) {
+            $include = '';
+            $has_explicit_ids = ! empty( $attributes['ids'] );
+            if ( $has_explicit_ids ) {
+                $include = $attributes['ids'];
+            } elseif ( ! empty( $attributes['include'] ) ) {
+                $include = $attributes['include'];
+            }
+
+            $order = ! empty( $attributes['order'] ) && 'DESC' === strtoupper( $attributes['order'] ) ? 'DESC' : 'ASC';
+            $orderby = ! empty( $attributes['orderby'] ) ? $attributes['orderby'] : 'menu_order ID';
+            if ( $has_explicit_ids && empty( $attributes['orderby'] ) ) {
+                $orderby = 'post__in';
+            }
+
+            $query = array(
+                'post_status'    => 'inherit',
+                'post_type'      => 'attachment',
+                'post_mime_type' => 'image',
+                'posts_per_page' => -1,
+                'fields'         => 'ids',
+                'order'          => $order,
+                'orderby'        => $orderby,
+            );
+
+            if ( '' !== $include ) {
+                $query['include'] = $include;
+            } else {
+                $query['post_parent'] = ! empty( $attributes['id'] ) ? absint( $attributes['id'] ) : (int) $post->ID;
+                if ( ! empty( $attributes['exclude'] ) ) {
+                    $query['post__not_in'] = array_map( 'absint', preg_split( '/\s*,\s*/', (string) $attributes['exclude'] ) );
+                }
+            }
+
+            return $this->normalize_attachment_ids( get_posts( $query ) );
+        }
+
+        /**
+         * Keep valid image attachments once, in source order.
+         *
+         * @param array $ids Candidate IDs.
+         * @return array
+         */
+        private function normalize_attachment_ids( $ids ) {
+            $normalized = array();
+            foreach ( (array) $ids as $id ) {
+                $id = absint( $id );
+                if ( $id <= 0 || isset( $normalized[ $id ] ) ) {
+                    continue;
+                }
+                $attachment = get_post( $id );
+                if ( ! $attachment || 'attachment' !== $attachment->post_type || 0 !== strpos( (string) $attachment->post_mime_type, 'image/' ) ) {
+                    continue;
+                }
+                $normalized[ $id ] = $id;
+            }
+
+            return array_values( $normalized );
+        }
+
+        /**
+         * Preserve only scalar, known gallery attributes.
+         *
+         * @param array $attributes Source attributes.
+         * @return array
+         */
+        private function normalize_attributes( $attributes ) {
+            $normalized = array();
+            $allowed = array( 'columns', 'link', 'linkTo', 'size', 'sizeSlug', 'imageCrop', 'orderby', 'order' );
+            foreach ( $allowed as $key ) {
+                if ( isset( $attributes[ $key ] ) && is_scalar( $attributes[ $key ] ) ) {
+                    $normalized[ $key ] = sanitize_text_field( (string) $attributes[ $key ] );
+                }
+            }
+
+            return $normalized;
+        }
+
+        /**
+         * Published posts and pages match the existing content migrator scope.
+         *
+         * @return array
+         */
+        private function get_eligible_posts() {
+            global $wpdb;
+
+            return $wpdb->get_results(
+                "SELECT ID, post_title, post_content, post_type, post_status
+                FROM {$wpdb->posts}
+                WHERE post_status = 'publish'
+                AND post_type IN ('post', 'page')
+                AND (post_content LIKE '%[gallery%' OR post_content LIKE '%wp:gallery%')
+                ORDER BY ID ASC"
+            );
+        }
+    }
+}

--- a/includes/plugins/class-word-press-core.php
+++ b/includes/plugins/class-word-press-core.php
@@ -17,6 +17,31 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Plugins\WordPressCore' ) ) {
      */
     class WordPressCore extends Plugin {
 
+        const SETTING_MODE = 'wordpress-core-mode';
+        const MODE_CREATE = 'create';
+        const MODE_DYNAMIC = 'dynamic';
+
+        /**
+         * Normalize the saved migration mode.
+         *
+         * @param string $mode Candidate mode.
+         * @return string
+         */
+        static function normalize_mode( $mode ) {
+            return self::MODE_DYNAMIC === $mode ? self::MODE_DYNAMIC : self::MODE_CREATE;
+        }
+
+        /**
+         * Return the selected WordPress core gallery migration mode.
+         *
+         * @return string
+         */
+        function get_migration_mode() {
+            return self::normalize_mode(
+                foogallery_migrate_migrator_instance()->get_migrator_setting( self::SETTING_MODE, self::MODE_CREATE )
+            );
+        }
+
         /**
          * Source name.
          *
@@ -48,6 +73,10 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Plugins\WordPressCore' ) ) {
          */
         function find_galleries() {
             $galleries = array();
+
+            if ( self::MODE_DYNAMIC === $this->get_migration_mode() ) {
+                return $galleries;
+            }
 
             foreach ( $this->get_eligible_posts() as $post ) {
                 foreach ( $this->find_content_occurrences( $post ) as $occurrence ) {
@@ -218,10 +247,68 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Plugins\WordPressCore' ) ) {
                     $number,
                     count( $occurrence['attachment_ids'] )
                 );
+                if ( self::MODE_DYNAMIC === $this->get_migration_mode() ) {
+                    $occurrence['replacement_content'] = $this->build_dynamic_replacement( $occurrence );
+                }
                 $occurrences[] = $occurrence;
             }
 
             return $occurrences;
+        }
+
+        /**
+         * Dynamic mode replaces source content without creating FooGallery posts.
+         *
+         * @param string $original_content Original shortcode or block markup.
+         * @param string $block_name Source block name.
+         * @return string
+         */
+        function get_content_object_type( $original_content, $block_name = '' ) {
+            return self::MODE_DYNAMIC === $this->get_migration_mode() ? 'dynamic_gallery' : 'gallery';
+        }
+
+        /**
+         * Build a dynamic FooGallery shortcode or block for one source occurrence.
+         *
+         * @param array $occurrence Parsed WordPress gallery occurrence.
+         * @return string
+         */
+        private function build_dynamic_replacement( $occurrence ) {
+            $attachment_ids = isset( $occurrence['attachment_ids'] ) ? array_values( array_map( 'absint', $occurrence['attachment_ids'] ) ) : array();
+            if ( empty( $attachment_ids ) ) {
+                return '';
+            }
+
+            $attributes = isset( $occurrence['attributes'] ) && is_array( $occurrence['attributes'] ) ? $occurrence['attributes'] : array();
+            $dynamic_options = array();
+            $template = foogallery_migrate_migrator_instance()->get_override_gallery_template();
+            if ( ! empty( $template ) ) {
+                $dynamic_options['template'] = sanitize_key( $template );
+            }
+
+            $link = isset( $attributes['link'] ) ? $attributes['link'] : ( isset( $attributes['linkTo'] ) ? $attributes['linkTo'] : '' );
+            if ( in_array( $link, array( 'file', 'media' ), true ) ) {
+                $dynamic_options['lightbox'] = 'foobox';
+            } elseif ( 'none' === $link ) {
+                $dynamic_options['lightbox'] = 'none';
+            }
+
+            if ( 'block' === $occurrence['type'] ) {
+                $block_attributes = array_merge(
+                    array( 'attachment_ids' => $attachment_ids ),
+                    $dynamic_options
+                );
+                return '<!-- wp:fooplugins/foogallery ' . wp_json_encode( $block_attributes ) . ' /-->';
+            }
+
+            $shortcode_attributes = array(
+                'attachment_ids="' . implode( ',', $attachment_ids ) . '"',
+            );
+            foreach ( $dynamic_options as $key => $value ) {
+                $shortcode_attributes[] = sanitize_key( $key ) . '="' . esc_attr( $value ) . '"';
+            }
+
+            return '[foogallery ' . implode( ' ', $shortcode_attributes ) . ']';
         }
 
         /**

--- a/includes/views/view-migrate-tab-content.php
+++ b/includes/views/view-migrate-tab-content.php
@@ -1,11 +1,26 @@
 <?php
     $migrator = foogallery_migrate_migrator_instance();
+    $result = isset( $content_migration_result ) && is_array( $content_migration_result ) ? $content_migration_result : false;
+    if ( is_array( $result ) ) {
+        if ( $result['success'] > 0 ) {
+            echo '<div class="notice notice-success inline"><p>';
+            printf(
+                /* translators: %d: migrated occurrence count. */
+                esc_html( _n( 'Successfully migrated and replaced %d gallery occurrence.', 'Successfully migrated and replaced %d gallery occurrences.', $result['success'], 'foogallery-migrate' ) ),
+                absint( $result['success'] )
+            );
+            echo '</p></div>';
+        }
+        foreach ( (array) $result['errors'] as $error ) {
+            echo '<div class="notice notice-error inline"><p>' . esc_html( $error ) . '</p></div>';
+        }
+    }
 ?>
 <script>
     jQuery(function ($) {
         var contentErrorMessage = <?php echo wp_json_encode( __( 'Something went wrong with the content migration and the page will now reload.', 'foogallery-migrate' ) ); ?>;
         var selectItemMessage = <?php echo wp_json_encode( __( 'Please select at least one item to replace.', 'foogallery-migrate' ) ); ?>;
-        var replaceConfirmMessage = <?php echo wp_json_encode( __( 'Are you sure you want to replace the selected shortcodes/blocks? This will update your post/page content.', 'foogallery-migrate' ) ); ?>;
+        var replaceConfirmMessage = <?php echo wp_json_encode( __( 'Migrate the selected galleries and replace these exact shortcode/block occurrences? This will update your post/page content.', 'foogallery-migrate' ) ); ?>;
 
         var $form = $('#foogallery_migrate_content_form');
 
@@ -71,6 +86,6 @@
         });
     });
 </script>
-<form id="foogallery_migrate_content_form" method="POST">
+<form id="foogallery_migrate_content_form" method="POST" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
     <?php $migrator->get_content_migrator()->render_content_form(); ?>
 </form>

--- a/includes/views/view-migrate-tab-sources.php
+++ b/includes/views/view-migrate-tab-sources.php
@@ -46,6 +46,30 @@
     <?php esc_html_e( 'We detected the following gallery plugins to migrate:', 'foogallery-migrate' ); ?>
 </p>
     <?php } ?>
+<?php
+$wordpress_gallery_detected = isset( $_GET['wordpress-gallery-detected'] ) ? sanitize_key( wp_unslash( $_GET['wordpress-gallery-detected'] ) ) : '';
+$wordpress_gallery_count = isset( $_GET['wordpress-gallery-count'] ) ? absint( wp_unslash( $_GET['wordpress-gallery-count'] ) ) : 0;
+if ( '0' === $wordpress_gallery_detected ) {
+    echo '<div class="notice notice-info inline"><p>' . esc_html__( 'No valid WordPress core galleries were found in published posts or pages.', 'foogallery-migrate' ) . '</p></div>';
+} elseif ( '1' === $wordpress_gallery_detected ) {
+    echo '<div class="notice notice-success inline"><p>';
+    printf(
+        /* translators: %d: detected gallery occurrence count. */
+        esc_html( _n( 'Found %d WordPress core gallery. You can migrate it in Blocks / Shortcodes.', 'Found %d WordPress core galleries. You can migrate them in Blocks / Shortcodes.', $wordpress_gallery_count, 'foogallery-migrate' ) ),
+        absint( $wordpress_gallery_count )
+    );
+    echo '</p></div>';
+}
+?>
+<div class="notice notice-info inline">
+    <p><strong><?php esc_html_e( 'Built-in WordPress galleries', 'foogallery-migrate' ); ?></strong></p>
+    <p><?php esc_html_e( 'Scan published posts and pages for valid [gallery] shortcodes and core Gallery blocks. Detection does not change content.', 'foogallery-migrate' ); ?></p>
+    <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+        <input type="hidden" name="action" value="foogallery_migrate_detect_wordpress_core">
+        <?php wp_nonce_field( 'foogallery_migrate_detect_wordpress_core' ); ?>
+        <button type="submit" class="button button-primary"><?php esc_html_e( 'Detect WordPress Galleries', 'foogallery-migrate' ); ?></button>
+    </form>
+</div>
 <ul>
     <?php
     foreach ( $migrator->get_plugins() as $plugin ) {

--- a/includes/views/view-migrate-tab-sources.php
+++ b/includes/views/view-migrate-tab-sources.php
@@ -53,6 +53,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 $wordpress_gallery_detected = isset( $_GET['wordpress-gallery-detected'] ) ? sanitize_key( wp_unslash( $_GET['wordpress-gallery-detected'] ) ) : '';
 $wordpress_gallery_count = isset( $_GET['wordpress-gallery-count'] ) ? absint( wp_unslash( $_GET['wordpress-gallery-count'] ) ) : 0;
 $wordpress_scan_complete = isset( $_GET['wordpress-scan-complete'] ) ? sanitize_key( wp_unslash( $_GET['wordpress-scan-complete'] ) ) : '';
+$wordpress_gallery_mode = \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore::normalize_mode(
+    $migrator->get_migrator_setting(
+        \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore::SETTING_MODE,
+        \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore::MODE_CREATE
+    )
+);
 if ( '' !== $wordpress_gallery_detected && '0' === $wordpress_scan_complete ) {
     echo '<div class="notice notice-info inline"><p>';
     printf(
@@ -73,14 +79,60 @@ if ( '' !== $wordpress_gallery_detected && '0' === $wordpress_scan_complete ) {
     echo '</p></div>';
 }
 ?>
-<div class="notice notice-info inline">
+<style>
+    .foogallery-wordpress-detection summary {
+        cursor: pointer;
+        display: inline-block;
+    }
+    .foogallery-wordpress-detection summary::marker,
+    .foogallery-wordpress-detection summary::-webkit-details-marker {
+        display: none;
+        content: '';
+    }
+    .foogallery-wordpress-mode-options {
+        margin: 16px 0 12px;
+        max-width: 760px;
+    }
+    .foogallery-wordpress-mode-option {
+        border-top: 1px solid #dcdcde;
+        display: grid;
+        gap: 4px 8px;
+        grid-template-columns: 20px 1fr;
+        padding: 12px 0;
+    }
+    .foogallery-wordpress-mode-option input {
+        margin-top: 2px;
+    }
+    .foogallery-wordpress-mode-option .description {
+        grid-column: 2;
+        margin: 0;
+    }
+</style>
+<div class="notice notice-info inline foogallery-wordpress-detection">
     <p><strong><?php esc_html_e( 'Built-in WordPress galleries', 'foogallery-migrate' ); ?></strong></p>
     <p><?php esc_html_e( 'Scan published posts and pages for valid [gallery] shortcodes and core Gallery blocks. Detection does not change content.', 'foogallery-migrate' ); ?></p>
-    <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-        <input type="hidden" name="action" value="foogallery_migrate_detect_wordpress_core">
-        <?php wp_nonce_field( 'foogallery_migrate_detect_wordpress_core' ); ?>
-        <button type="submit" class="button button-primary"><?php esc_html_e( 'Detect WordPress Galleries', 'foogallery-migrate' ); ?></button>
-    </form>
+    <details>
+        <summary class="button button-primary"><?php esc_html_e( 'Detect WordPress Galleries', 'foogallery-migrate' ); ?></summary>
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+            <input type="hidden" name="action" value="foogallery_migrate_detect_wordpress_core">
+            <?php wp_nonce_field( 'foogallery_migrate_detect_wordpress_core' ); ?>
+            <fieldset class="foogallery-wordpress-mode-options">
+                <legend><strong><?php esc_html_e( 'Choose how WordPress galleries should be migrated', 'foogallery-migrate' ); ?></strong></legend>
+                <label class="foogallery-wordpress-mode-option">
+                    <input type="radio" name="wordpress_gallery_mode" value="<?php echo esc_attr( \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore::MODE_DYNAMIC ); ?>" <?php checked( $wordpress_gallery_mode, \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore::MODE_DYNAMIC ); ?>>
+                    <strong><?php esc_html_e( 'Replace with dynamic FooGalleries', 'foogallery-migrate' ); ?></strong>
+                    <span class="description"><?php esc_html_e( 'Stores the image selection directly in each post or page. No FooGallery records are created, and results appear only in Blocks / Shortcodes.', 'foogallery-migrate' ); ?></span>
+                </label>
+                <label class="foogallery-wordpress-mode-option">
+                    <input type="radio" name="wordpress_gallery_mode" value="<?php echo esc_attr( \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore::MODE_CREATE ); ?>" <?php checked( $wordpress_gallery_mode, \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore::MODE_CREATE ); ?>>
+                    <strong><?php esc_html_e( 'Create reusable FooGallery records', 'foogallery-migrate' ); ?></strong>
+                    <span class="description"><?php esc_html_e( 'Creates an editable FooGallery for each occurrence, then replaces the source content with its ID. Results appear in Galleries and Blocks / Shortcodes.', 'foogallery-migrate' ); ?></span>
+                </label>
+            </fieldset>
+            <p class="description"><?php esc_html_e( 'Changing mode does not delete FooGalleries created by an earlier migration.', 'foogallery-migrate' ); ?></p>
+            <p><button type="submit" class="button button-primary"><?php esc_html_e( 'Scan WordPress Galleries', 'foogallery-migrate' ); ?></button></p>
+        </form>
+    </details>
 </div>
 <ul>
     <?php

--- a/readme.txt
+++ b/readme.txt
@@ -26,12 +26,14 @@ Migrate to FooGallery from other gallery plugins, including:
 *	Photo Gallery by 10Web
 *	Robo Gallery
 *	Album and Image Gallery Plus Lightbox (plugin was closed Apr 2026 due to being compromised)
+*	Built-in WordPress Gallery blocks and [gallery] shortcodes
 
 Features:
 
 * Migrate images and galleries
 * Migrate albums
 * Migrate blocks / shortcodes in post & page content
+* Choose whether built-in WordPress galleries create reusable FooGallery records or become dynamic FooGalleries stored directly in content
 
 = Test It First =
 
@@ -80,6 +82,7 @@ Update now to get all the latest features, bug fixes and improvements!
 == Changelog ==
 
 = 1.13 =
+* Added two migration modes for built-in WordPress galleries: reusable FooGallery records or direct dynamic FooGallery replacements.
 * Added direct-access guards to plugin include and view files.
 * Hardened legacy NextGEN and 10Web album queries with sanitized IDs and prepared SQL.
 * Escaped migrated album edit links on the album migration screen.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fooplugins,bradvin,elviiso
 Tags: gallery, image gallery, photo gallery, wordpress gallery plugin, migrate
 Requires at least: 6.0
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 5.4
 Stable tag: 1.7
 License: GPLv2 or later

--- a/tests/integration/core-gallery-migration.php
+++ b/tests/integration/core-gallery-migration.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * Integration regression for WP core gallery migration.
+ *
+ * Run inside a disposable WordPress site with:
+ * wp eval-file tests/integration/core-gallery-migration.php
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    throw new RuntimeException( 'WordPress must be loaded.' );
+}
+
+function foogm_test_assert( $condition, $message ) {
+    if ( ! $condition ) {
+        throw new RuntimeException( $message );
+    }
+}
+
+function foogm_test_attachment( $label ) {
+    return wp_insert_attachment(
+        array(
+            'post_title'     => 'FooGallery Migrate Test ' . $label,
+            'post_status'    => 'inherit',
+            'post_mime_type' => 'image/png',
+            'guid'           => trailingslashit( wp_get_upload_dir()['baseurl'] ) . 'foogm-test-' . strtolower( $label ) . '.png',
+        )
+    );
+}
+
+$created_posts = array();
+$created_attachments = array();
+$created_galleries = array();
+$failure = false;
+
+try {
+    $created_attachments[] = $first_id = foogm_test_attachment( 'First' );
+    $created_attachments[] = $second_id = foogm_test_attachment( 'Second' );
+    $missing_id = 99999999;
+
+    $shortcode = '[gallery ids="' . $first_id . ',' . $second_id . ',' . $first_id . ',' . $missing_id . '" columns="3" link="file" size="medium" orderby="post__in"]';
+    $identical = '[gallery ids="' . $second_id . ',' . $first_id . '" columns="2"]';
+    $block = '<!-- wp:group --><div class="wp-block-group"><!-- wp:gallery {"columns":2,"imageCrop":false,"linkTo":"media"} --><figure class="wp-block-gallery has-nested-images columns-2"><!-- wp:image {"id":' . $second_id . ',"sizeSlug":"large"} --><figure class="wp-block-image size-large"></figure><!-- /wp:image --><!-- wp:image {"id":' . $first_id . ',"sizeSlug":"large"} --><figure class="wp-block-image size-large"></figure><!-- /wp:image --></figure><!-- /wp:gallery --></div><!-- /wp:group -->';
+    $content = 'Escaped mention: [[gallery ids="' . $first_id . '"]]' . "\n\n" . $shortcode . "\n\n" . $block . "\n\n" . $identical . "\n\n" . $identical;
+
+    $created_posts[] = $post_id = wp_insert_post(
+        array(
+            'post_title'   => 'FooGallery Migrate Integration Fixture',
+            'post_type'    => 'post',
+            'post_status'  => 'publish',
+            'post_content' => $content,
+        )
+    );
+    $created_posts[] = wp_insert_post(
+        array(
+            'post_title'   => 'FooGallery Migrate Draft Fixture',
+            'post_type'    => 'post',
+            'post_status'  => 'draft',
+            'post_content' => $shortcode,
+        )
+    );
+    $created_posts[] = wp_insert_post(
+        array(
+            'post_title'   => 'FooGallery Migrate Malformed Fixture',
+            'post_type'    => 'page',
+            'post_status'  => 'publish',
+            'post_content' => '[gallery ids=""] <!-- wp:gallery --><p>empty</p><!-- /wp:gallery -->',
+        )
+    );
+    $created_posts[] = $attached_post_id = wp_insert_post(
+        array(
+            'post_title'   => 'FooGallery Migrate Attached Images Fixture',
+            'post_type'    => 'page',
+            'post_status'  => 'publish',
+            'post_content' => '[gallery columns="2" exclude="' . $missing_id . '"]',
+        )
+    );
+    wp_update_post( array( 'ID' => $first_id, 'post_parent' => $attached_post_id, 'menu_order' => 1 ) );
+    wp_update_post( array( 'ID' => $second_id, 'post_parent' => $attached_post_id, 'menu_order' => 2 ) );
+
+    delete_option( FOOGALLERY_MIGRATE_OPTION_DATA );
+    $migrator = foogallery_migrate_migrator_instance();
+    $plugins = $migrator->run_detection();
+    $core_plugin = false;
+    foreach ( $plugins as $plugin ) {
+        if ( 'WordPress Core' === $plugin->name() ) {
+            $core_plugin = $plugin;
+            break;
+        }
+    }
+
+    foogm_test_assert( false !== $core_plugin, 'WP core must be a first-class migration source.' );
+    foogm_test_assert( $core_plugin->is_detected, 'Published WP core galleries must be detected.' );
+    $test_init = new \FooPlugins\FooGalleryMigrate\Init();
+    foogm_test_assert( false !== has_action( 'admin_post_foogallery_migrate_detect_wordpress_core' ), 'The no-JS core detection handler must be registered.' );
+    foogm_test_assert( false !== has_action( 'admin_post_foogallery_migrate_content' ), 'The no-JS content migration handler must be registered.' );
+
+    ob_start();
+    require FOOGM_DIR . '/includes/views/view-migrate-tab-sources.php';
+    $source_view = ob_get_clean();
+    foogm_test_assert( false !== strpos( $source_view, 'Detect WordPress Galleries' ), 'The Plugins tab must provide a clear core gallery detection action.' );
+    foogm_test_assert( false !== strpos( $source_view, 'admin-post.php' ), 'Core detection must work without JavaScript.' );
+
+    $attached_occurrences = $core_plugin->find_content_occurrences( get_post( $attached_post_id ) );
+    foogm_test_assert( 1 === count( $attached_occurrences ), 'A classic [gallery] without explicit IDs must resolve attached images.' );
+    foogm_test_assert( array( $first_id, $second_id ) === $attached_occurrences[0]['attachment_ids'], 'Attached-image gallery order must follow menu order.' );
+
+    $spaced_block = '<!-- wp:gallery { "ids" : [' . $second_id . ', ' . $first_id . '], "columns" : 2 } /-->';
+    $hybrid_block = '<!-- wp:gallery {"ids":[' . $first_id . ',' . $second_id . ']} --><figure class="wp-block-gallery"><!-- wp:image {"id":' . $second_id . '} --><figure></figure><!-- /wp:image --><!-- wp:image {"id":' . $first_id . '} --><figure></figure><!-- /wp:image --></figure><!-- /wp:gallery -->';
+    $ordered_shortcode = '[gallery include="' . $first_id . ',' . $second_id . '" orderby="ID" order="DESC"]';
+    $created_posts[] = $formatting_post_id = wp_insert_post(
+        array(
+            'post_title'   => 'FooGallery Migrate Formatting Fixture',
+            'post_type'    => 'page',
+            'post_status'  => 'publish',
+            'post_content' => $spaced_block . "\n" . $spaced_block . "\n" . $hybrid_block . "\n" . $ordered_shortcode,
+        )
+    );
+    $formatting_occurrences = $core_plugin->find_content_occurrences( get_post( $formatting_post_id ) );
+    foogm_test_assert( 4 === count( $formatting_occurrences ), 'Noncanonical and repeated gallery blocks must be detected exactly.' );
+    foogm_test_assert( $spaced_block === $formatting_occurrences[0]['original_content'], 'Stored block formatting must remain exact.' );
+    foogm_test_assert( $formatting_occurrences[0]['match_offset'] !== $formatting_occurrences[1]['match_offset'], 'Repeated blocks must have distinct offsets.' );
+    foogm_test_assert( array( $second_id, $first_id ) === $formatting_occurrences[0]['attachment_ids'], 'Block image order must follow source IDs.' );
+    foogm_test_assert( array( $second_id, $first_id ) === $formatting_occurrences[2]['attachment_ids'], 'Nested image order must override conflicting legacy parent IDs.' );
+    foogm_test_assert( array( max( $first_id, $second_id ), min( $first_id, $second_id ) ) === $formatting_occurrences[3]['attachment_ids'], 'Shortcode orderby and order attributes must match WordPress core.' );
+
+    $galleries = array();
+    foreach ( $core_plugin->find_galleries() as $gallery ) {
+        if ( isset( $gallery->data['post_id'] ) && (int) $gallery->data['post_id'] === (int) $post_id ) {
+            $galleries[] = $gallery;
+        }
+    }
+    foogm_test_assert( 4 === count( $galleries ), 'Expected shortcode, nested block, and two identical shortcode occurrences; got ' . count( $galleries ) . '.' );
+    foogm_test_assert( 2 === count( $galleries[0]->children ), 'Missing and duplicate attachment IDs must be removed.' );
+    foogm_test_assert( $first_id === (int) $galleries[0]->children[0]->migrated_id, 'Attachment order must preserve the first image.' );
+    foogm_test_assert( $second_id === (int) $galleries[0]->children[1]->migrated_id, 'Attachment order must preserve the second image.' );
+    foogm_test_assert( '3' === (string) $galleries[0]->data['attributes']['columns'], 'Safely preservable shortcode attributes must remain available.' );
+
+    $items = $migrator->get_content_migrator()->scan_content( true );
+    $core_items = array();
+    foreach ( $items as $key => $item ) {
+        if ( 'WordPress Core' === $item['plugin_name'] && (int) $item['post_id'] === (int) $post_id ) {
+            $core_items[ $key ] = $item;
+        }
+    }
+    foogm_test_assert( 4 === count( $core_items ), 'Blocks / Shortcodes must list every valid core occurrence.' );
+    foogm_test_assert( 'block' === array_values( $core_items )[1]['type'], 'Nested core/gallery must be listed as a block.' );
+    foogm_test_assert( ! empty( array_values( $core_items )[0]['source_context'] ), 'Each occurrence must include source context.' );
+
+    ob_start();
+    require FOOGM_DIR . '/includes/views/view-migrate-tab-content.php';
+    $content_view = ob_get_clean();
+    foogm_test_assert( false !== strpos( $content_view, 'Migrate &amp; Replace Selected' ), 'Core occurrences must expose a batch migrate-and-replace action.' );
+    foogm_test_assert( false !== strpos( $content_view, 'admin-post.php' ), 'Content migration must submit to the admin-post controller without JavaScript.' );
+    foogm_test_assert( false !== strpos( $content_view, 'value="foogallery_migrate_content"' ), 'Content migration must retain a no-JS submit action.' );
+    foogm_test_assert( false !== strpos( $content_view, 'Gallery shortcode' ), 'The content table must show per-occurrence source context.' );
+
+    $identical_keys = array();
+    foreach ( $core_items as $key => $item ) {
+        if ( $identical === $item['original_content'] ) {
+            $identical_keys[] = $key;
+        }
+    }
+    foogm_test_assert( 2 === count( $identical_keys ), 'Both identical shortcode occurrences must be independently addressable.' );
+
+    $mixed_items = $items;
+    $mixed_items[] = array_merge(
+        $mixed_items[ $identical_keys[0] ],
+        array(
+            'plugin_name'             => 'Legacy Fixture',
+            'original_content'        => '[stale-legacy-gallery]',
+            'match_offset'            => 0,
+            'migrated'                => true,
+            'migrated_foogallery_id'  => 1,
+        )
+    );
+    $mixed_item_key = count( $mixed_items ) - 1;
+    $migrator->get_content_migrator()->set_setting( 'content', $mixed_items );
+    $gallery_count_before_mixed_attempt = (int) wp_count_posts( FOOGALLERY_CPT_GALLERY )->publish;
+    $mixed_result = $migrator->get_content_migrator()->migrate_and_replace_content( array( $identical_keys[0], $mixed_item_key ) );
+    foogm_test_assert( 0 === $mixed_result['success'] && ! empty( $mixed_result['errors'] ), 'A stale mixed-selection item must fail the complete preflight.' );
+    foogm_test_assert( $gallery_count_before_mixed_attempt === (int) wp_count_posts( FOOGALLERY_CPT_GALLERY )->publish, 'Mixed-selection preflight failure must not create a core FooGallery entity.' );
+    $migrator->get_content_migrator()->set_setting( 'content', $items );
+
+    $gallery_count_before_stale_attempt = (int) wp_count_posts( FOOGALLERY_CPT_GALLERY )->publish;
+    $stale_item = $core_items[ $identical_keys[0] ];
+    $stale_content = substr_replace( $content, '[gallery ids="changed"]', $stale_item['match_offset'], strlen( $stale_item['original_content'] ) );
+    wp_update_post( array( 'ID' => $post_id, 'post_content' => $stale_content ) );
+    $stale_result = $migrator->get_content_migrator()->migrate_and_replace_content( array( $identical_keys[0] ) );
+    foogm_test_assert( 0 === $stale_result['success'] && ! empty( $stale_result['errors'] ), 'Changed content must fail preflight before migration.' );
+    foogm_test_assert( $gallery_count_before_stale_attempt === (int) wp_count_posts( FOOGALLERY_CPT_GALLERY )->publish, 'A stale occurrence must not create a FooGallery entity.' );
+
+    wp_update_post( array( 'ID' => $post_id, 'post_content' => $content ) );
+    $items = $migrator->get_content_migrator()->scan_content( true );
+    $identical_keys = array();
+    foreach ( $items as $key => $item ) {
+        if ( 'WordPress Core' === $item['plugin_name'] && (int) $item['post_id'] === (int) $post_id && $identical === $item['original_content'] ) {
+            $identical_keys[] = $key;
+        }
+    }
+    foogm_test_assert( 2 === count( $identical_keys ), 'Restored identical occurrences must be rescanned.' );
+
+    $gallery_count_before_draft_attempt = (int) wp_count_posts( FOOGALLERY_CPT_GALLERY )->publish;
+    wp_update_post( array( 'ID' => $post_id, 'post_status' => 'draft' ) );
+    $draft_result = $migrator->get_content_migrator()->migrate_and_replace_content( array( $identical_keys[0] ) );
+    foogm_test_assert( 0 === $draft_result['success'] && ! empty( $draft_result['errors'] ), 'A post that is no longer published must fail migration preflight.' );
+    foogm_test_assert( $gallery_count_before_draft_attempt === (int) wp_count_posts( FOOGALLERY_CPT_GALLERY )->publish, 'A draft source must not create a FooGallery entity.' );
+    wp_update_post( array( 'ID' => $post_id, 'post_status' => 'publish' ) );
+
+    $items = $migrator->get_content_migrator()->scan_content( true );
+    $identical_keys = array();
+    foreach ( $items as $key => $item ) {
+        if ( 'WordPress Core' === $item['plugin_name'] && (int) $item['post_id'] === (int) $post_id && $identical === $item['original_content'] ) {
+            $identical_keys[] = $key;
+        }
+    }
+    foogm_test_assert( 2 === count( $identical_keys ), 'Republished occurrences must be rescanned.' );
+
+    $result = $migrator->get_content_migrator()->migrate_and_replace_content( array( $identical_keys[0] ) );
+    foogm_test_assert( 1 === $result['success'], 'One selected occurrence must migrate and replace successfully.' );
+    $after_first = get_post( $post_id )->post_content;
+    foogm_test_assert( 1 === substr_count( $after_first, $identical ), 'Replacing one occurrence must not replace an identical sibling.' );
+    foogm_test_assert( 1 === substr_count( $after_first, '[foogallery id="' ), 'The exact selected occurrence must become one FooGallery reference.' );
+
+    $gallery_count = (int) wp_count_posts( FOOGALLERY_CPT_GALLERY )->publish;
+    $retry = $migrator->get_content_migrator()->migrate_and_replace_content( array( $identical_keys[0] ) );
+    foogm_test_assert( 0 === $retry['success'], 'Retrying a replaced occurrence must be a no-op.' );
+    foogm_test_assert( $gallery_count === (int) wp_count_posts( FOOGALLERY_CPT_GALLERY )->publish, 'Retry must not duplicate FooGallery entities.' );
+
+    foreach ( $migrator->get_migrated_objects() as $object ) {
+        if ( is_object( $object ) && 'gallery' === $object->type() && 'WordPress Core' === $object->plugin->name() ) {
+            $created_galleries[] = (int) $object->migrated_id;
+        }
+    }
+} catch ( Exception $exception ) {
+    $failure = $exception;
+}
+
+foreach ( array_unique( $created_galleries ) as $gallery_id ) {
+    if ( $gallery_id > 0 ) {
+        wp_delete_post( $gallery_id, true );
+    }
+}
+foreach ( array_unique( $created_posts ) as $post_id ) {
+    if ( $post_id > 0 ) {
+        wp_delete_post( $post_id, true );
+    }
+}
+foreach ( array_unique( $created_attachments ) as $attachment_id ) {
+    if ( $attachment_id > 0 ) {
+        wp_delete_attachment( $attachment_id, true );
+    }
+}
+delete_option( FOOGALLERY_MIGRATE_OPTION_DATA );
+
+if ( $failure ) {
+    throw $failure;
+}
+
+echo "PASS: WP core gallery detection, parsing, exact replacement, order, attributes, and idempotency.\n";

--- a/tests/integration/core-gallery-migration.php
+++ b/tests/integration/core-gallery-migration.php
@@ -48,6 +48,15 @@ function foogm_test_set_content_items( $content_migrator, $items ) {
     );
 }
 
+function foogm_test_find_core_plugin( $plugins ) {
+    foreach ( $plugins as $plugin ) {
+        if ( 'WordPress Core' === $plugin->name() ) {
+            return $plugin;
+        }
+    }
+    return false;
+}
+
 $created_posts = array();
 $created_attachments = array();
 $created_galleries = array();
@@ -103,13 +112,7 @@ try {
     delete_option( FOOGALLERY_MIGRATE_OPTION_DATA );
     $migrator = foogallery_migrate_migrator_instance();
     $plugins = $migrator->run_detection();
-    $core_plugin = false;
-    foreach ( $plugins as $plugin ) {
-        if ( 'WordPress Core' === $plugin->name() ) {
-            $core_plugin = $plugin;
-            break;
-        }
-    }
+    $core_plugin = foogm_test_find_core_plugin( $plugins );
 
     foogm_test_assert( false !== $core_plugin, 'WP core must be a first-class migration source.' );
     foogm_test_assert( $core_plugin->is_detected, 'Published WP core galleries must be detected.' );
@@ -122,6 +125,9 @@ try {
     $source_view = ob_get_clean();
     foogm_test_assert( false !== strpos( $source_view, 'Detect WordPress Galleries' ), 'The Plugins tab must provide a clear core gallery detection action.' );
     foogm_test_assert( false !== strpos( $source_view, 'admin-post.php' ), 'Core detection must work without JavaScript.' );
+    foogm_test_assert( false !== strpos( $source_view, 'Replace with dynamic FooGalleries' ), 'The Plugins tab must explain dynamic replacement mode.' );
+    foogm_test_assert( false !== strpos( $source_view, 'Create reusable FooGallery records' ), 'The Plugins tab must explain reusable FooGallery mode.' );
+    foogm_test_assert( false !== strpos( $source_view, 'name="wordpress_gallery_mode"' ), 'The mode chooser must submit an explicit WordPress gallery mode.' );
 
     $attached_occurrences = $core_plugin->find_content_occurrences( get_post( $attached_post_id ) );
     foogm_test_assert( 1 === count( $attached_occurrences ), 'A classic [gallery] without explicit IDs must resolve attached images.' );
@@ -158,6 +164,67 @@ try {
     foogm_test_assert( $second_id === (int) $galleries[0]->children[1]->migrated_id, 'Attachment order must preserve the second image.' );
     foogm_test_assert( '3' === (string) $galleries[0]->data['attributes']['columns'], 'Safely preservable shortcode attributes must remain available.' );
 
+    $migrator->set_migrator_setting(
+        \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore::SETTING_MODE,
+        \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore::MODE_DYNAMIC
+    );
+    $plugins = $migrator->run_detection();
+    $core_plugin = foogm_test_find_core_plugin( $plugins );
+    foogm_test_assert( \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore::MODE_DYNAMIC === $core_plugin->get_migration_mode(), 'Dynamic mode must be persisted.' );
+    foogm_test_assert( array() === $core_plugin->find_galleries(), 'Dynamic mode must not add WordPress Core rows to the Galleries tab.' );
+
+    $dynamic_items = foogm_test_scan_all_content( $migrator->get_content_migrator() );
+    $dynamic_keys = array();
+    $dynamic_shortcode_item = false;
+    $dynamic_block_item = false;
+    foreach ( $dynamic_items as $key => $item ) {
+        if ( 'WordPress Core' !== $item['plugin_name'] || (int) $item['post_id'] !== (int) $post_id ) {
+            continue;
+        }
+        if ( false === $dynamic_shortcode_item && $shortcode === $item['original_content'] ) {
+            $dynamic_shortcode_item = $item;
+            $dynamic_keys[] = $key;
+        } elseif ( false === $dynamic_block_item && 'block' === $item['type'] ) {
+            $dynamic_block_item = $item;
+            $dynamic_keys[] = $key;
+        }
+    }
+    foogm_test_assert( 2 === count( $dynamic_keys ), 'Dynamic mode must expose the fixture shortcode and block as direct replacements.' );
+    foogm_test_assert( 'dynamic_gallery' === $dynamic_shortcode_item['object_type'], 'Dynamic shortcode items must be labeled as dynamic galleries.' );
+    $dynamic_shortcode_expected = '[foogallery attachment_ids="' . $first_id . ',' . $second_id . '"';
+    $dynamic_override_template = $migrator->get_override_gallery_template();
+    if ( ! empty( $dynamic_override_template ) ) {
+        $dynamic_shortcode_expected .= ' template="' . sanitize_key( $dynamic_override_template ) . '"';
+    }
+    $dynamic_shortcode_expected .= ' lightbox="foobox"]';
+    foogm_test_assert( $dynamic_shortcode_expected === $dynamic_shortcode_item['replacement_content'], 'Dynamic shortcode replacement must preserve normalized image order, the selected layout override, and lightbox behavior; got ' . $dynamic_shortcode_item['replacement_content'] . '.' );
+    foogm_test_assert( false !== strpos( $dynamic_block_item['replacement_content'], '"attachment_ids":[' . $second_id . ',' . $first_id . ']' ), 'Dynamic block replacement must preserve nested image order.' );
+
+    ob_start();
+    require FOOGM_DIR . '/includes/views/view-migrate-tab-content.php';
+    $dynamic_content_view = ob_get_clean();
+    foogm_test_assert( false !== strpos( $dynamic_content_view, 'Dynamic replacement mode' ), 'The content tab must identify dynamic mode.' );
+    foogm_test_assert( false !== strpos( $dynamic_content_view, 'Ready to replace' ), 'Dynamic core occurrences must be ready for direct replacement.' );
+
+    $gallery_count_before_dynamic = (int) wp_count_posts( FOOGALLERY_CPT_GALLERY )->publish;
+    $dynamic_result = $migrator->get_content_migrator()->migrate_and_replace_content( $dynamic_keys );
+    foogm_test_assert( 2 === $dynamic_result['success'], 'Dynamic mode must replace the selected shortcode and block.' );
+    foogm_test_assert( $gallery_count_before_dynamic === (int) wp_count_posts( FOOGALLERY_CPT_GALLERY )->publish, 'Dynamic mode must not create FooGallery records.' );
+    $dynamic_content = get_post( $post_id )->post_content;
+    foogm_test_assert( false === strpos( $dynamic_content, $shortcode ), 'The selected WordPress shortcode must be removed in dynamic mode.' );
+    foogm_test_assert( false === strpos( $dynamic_content, '<!-- wp:gallery' ), 'The selected WordPress Gallery block must be removed in dynamic mode.' );
+    foogm_test_assert( false !== strpos( $dynamic_content, $dynamic_shortcode_item['replacement_content'] ), 'The dynamic FooGallery shortcode must be stored in the post.' );
+    foogm_test_assert( false !== strpos( $dynamic_content, $dynamic_block_item['replacement_content'] ), 'The dynamic FooGallery block must be stored in the post.' );
+
+    wp_update_post( array( 'ID' => $post_id, 'post_content' => $content ) );
+    $migrator->set_migrator_setting(
+        \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore::SETTING_MODE,
+        \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore::MODE_CREATE
+    );
+    $plugins = $migrator->run_detection();
+    $core_plugin = foogm_test_find_core_plugin( $plugins );
+    foogm_test_assert( \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore::MODE_CREATE === $core_plugin->get_migration_mode(), 'Reusable FooGallery mode must be persisted.' );
+
     $items = foogm_test_scan_all_content( $migrator->get_content_migrator() );
     $core_items = array();
     foreach ( $items as $key => $item ) {
@@ -176,6 +243,7 @@ try {
     foogm_test_assert( false !== strpos( $content_view, 'admin-post.php' ), 'Content migration must submit to the admin-post controller without JavaScript.' );
     foogm_test_assert( false !== strpos( $content_view, 'value="foogallery_migrate_content"' ), 'Content migration must retain a no-JS submit action.' );
     foogm_test_assert( false !== strpos( $content_view, 'Gallery shortcode' ), 'The content table must show per-occurrence source context.' );
+    foogm_test_assert( false !== strpos( $content_view, 'Reusable FooGallery mode' ), 'The content tab must identify reusable mode.' );
 
     $identical_keys = array();
     foreach ( $core_items as $key => $item ) {
@@ -282,4 +350,4 @@ if ( $failure ) {
     throw $failure;
 }
 
-echo "PASS: WP core gallery detection, parsing, exact replacement, order, attributes, and idempotency.\n";
+echo "PASS: WP core gallery detection, dynamic replacement, reusable migration, exact replacement, order, attributes, and idempotency.\n";


### PR DESCRIPTION
## Summary
- detect valid WordPress `[gallery]` shortcodes and `core/gallery` blocks in published posts and pages
- migrate selected core galleries through the existing gallery migration engine, then replace exact source occurrences
- add capability/nonce-protected AJAX and no-JS admin handlers with stale-content, published-scope, and idempotency safeguards
- preserve core attachment ordering and relevant gallery attributes, including attached-image galleries without explicit IDs
- add a real WordPress integration fixture covering parsing, registration, exact replacement, failure preflight, and retries

## Verification
- `git diff --check upstream/master`
- PHP syntax: all 33 tracked/untracked PHP files pass `php -l`
- `composer validate --no-check-publish` (passes; pre-existing non-SPDX license warning)
- `frankenphp php-cli /home/brad/.local/bin/wp eval-file /home/brad/repos/worktrees/foogallery-migrate-core-galleries/tests/integration/core-gallery-migration.php` from the Cove WordPress root
  - `PASS: WP core gallery detection, parsing, exact replacement, order, attributes, and idempotency.`

## Scope
- detection intentionally remains limited to published `post` and `page` content
- no deployment, release, or wordpress.org publication is included