### PR TITLE
feat: add WP Photo Album Plus migrator

### DIFF
--- a/includes/class-init.php
+++ b/includes/class-init.php
@@ -318,6 +318,30 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Init' ) ) {
         }
 
         /**
+         * Read a submitted migration title, including PHP-normalized field names.
+         *
+         * PHP converts spaces and dots in top-level request keys to underscores.
+         * Source identifiers can contain plugin names with spaces, so check both
+         * the literal form field name and the normalized key received by PHP.
+         *
+         * @param string $object_id Source object identifier.
+         * @param string $prefix Form field prefix.
+         * @return string|false
+         */
+        private function get_migration_title_from_request( $object_id, $prefix = 'foogallery-title-' ) {
+            $field_name = $prefix . $object_id;
+            $request_key = $field_name;
+            if ( ! array_key_exists( $request_key, $_POST ) ) {
+                $request_key = str_replace( array( ' ', '.' ), '_', $field_name );
+            }
+            if ( ! array_key_exists( $request_key, $_POST ) ) {
+                return false;
+            }
+
+            return $_POST[ $request_key ];
+        }
+
+        /**
          * Start the gallery migration!
          *
          * @return void
@@ -342,8 +366,9 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Init' ) ) {
                             'migrated' => false,
                             'current' => false,
                         );
-                        if ( array_key_exists( 'foogallery-title-' . $gallery_id, $_POST ) ) {
-                            $migrations[$gallery_id]['title'] = sanitize_text_field( wp_unslash( $_POST[ 'foogallery-title-' . $gallery_id ] ) );
+                        $submitted_title = $this->get_migration_title_from_request( $gallery_id );
+                        if ( false !== $submitted_title ) {
+                            $migrations[$gallery_id]['title'] = sanitize_text_field( wp_unslash( $submitted_title ) );
                         }
                     }
 
@@ -503,8 +528,9 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Init' ) ) {
                             'migrated' => false,
                             'current' => false,
                         );
-                        if ( array_key_exists( 'foogallery-album-title-' . $album_id, $_POST ) ) {
-                            $migrations[$album_id]['title'] = sanitize_text_field( wp_unslash( $_POST[ 'foogallery-album-title-' . $album_id ] ) );
+                        $submitted_title = $this->get_migration_title_from_request( $album_id, 'foogallery-album-title-' );
+                        if ( false !== $submitted_title ) {
+                            $migrations[$album_id]['title'] = sanitize_text_field( wp_unslash( $submitted_title ) );
                         }
                     }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -124,6 +124,7 @@ function foogallery_migrate_get_available_plugins() {
     $plugins[] = new \FooPlugins\FooGalleryMigrate\Plugins\Robo();
     $plugins[] = new \FooPlugins\FooGalleryMigrate\Plugins\Photo();
     $plugins[] = new \FooPlugins\FooGalleryMigrate\Plugins\Aigpl();
+    $plugins[] = new \FooPlugins\FooGalleryMigrate\Plugins\WpPhotoAlbumPlus();
     $plugins[] = new \FooPlugins\FooGalleryMigrate\Plugins\WordPressCore();
 
     return $plugins;

--- a/includes/migrators/class-content-migrator.php
+++ b/includes/migrators/class-content-migrator.php
@@ -384,6 +384,10 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 						}
 					}
 
+					if ( method_exists( $plugin, 'uses_exclusive_content_occurrences' ) && $plugin->uses_exclusive_content_occurrences() ) {
+						continue;
+					}
+
 					$block_patterns = $plugin->get_block_patterns();
 					if ( ! empty( $block_patterns ) && is_array( $block_patterns ) && ! empty( $all_blocks ) ) {
 						foreach ( $block_patterns as $block_name => $pattern ) {
@@ -558,6 +562,10 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 		private function extract_gallery_id_from_match( $match, $plugin ) {
 			$extracted_id = false;
 
+			if ( method_exists( $plugin, 'get_content_match_identifier' ) ) {
+				return $plugin->get_content_match_identifier( $match );
+			}
+
 			$id = $this->get_first_numeric_match( $match );
 			if ( false !== $id ) {
 				$extracted_id = $id;
@@ -721,6 +729,10 @@ if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator' ) 
 		 */
 		private function extract_gallery_id_from_block( $block, $plugin ) {
 			$extracted_id = false;
+
+			if ( method_exists( $plugin, 'get_content_block_identifier' ) ) {
+				return $plugin->get_content_block_identifier( $block );
+			}
 
 			if ( isset( $block['attrs'] ) && is_array( $block['attrs'] ) ) {
 				$attrs = $block['attrs'];

--- a/includes/plugins/class-wp-photo-album-plus.php
+++ b/includes/plugins/class-wp-photo-album-plus.php
@@ -1,0 +1,965 @@
+<?php
+/**
+ * FooGallery Migrator WP Photo Album Plus Plugin Class
+ *
+ * @package FooPlugins\FooGalleryMigrate
+ */
+
+namespace FooPlugins\FooGalleryMigrate\Plugins;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+use FooPlugins\FooGalleryMigrate\Objects\Plugin;
+
+if ( ! class_exists( 'FooPlugins\FooGalleryMigrate\Plugins\WpPhotoAlbumPlus' ) ) {
+
+    /**
+     * Migrate public local images from WP Photo Album Plus.
+     */
+    class WpPhotoAlbumPlus extends Plugin {
+
+        /** @var array */
+        private $album_rows = null;
+
+        /** @var array */
+        private $photo_rows = null;
+
+        /** @var array */
+        private $valid_photos_by_album = null;
+
+        /** @var array */
+        private $galleries_by_id = null;
+
+        /**
+         * Keep request-only source data out of persisted migration state.
+         *
+         * @return array
+         */
+        public function __sleep() {
+            return array( 'is_detected' );
+        }
+
+        /**
+         * Reset request-only caches after legacy serialized state is loaded.
+         *
+         * @return void
+         */
+        public function __wakeup() {
+            $this->album_rows = null;
+            $this->photo_rows = null;
+            $this->valid_photos_by_album = null;
+            $this->galleries_by_id = null;
+        }
+
+        /**
+         * Source name used in persisted migration identifiers.
+         *
+         * @return string
+         */
+        function name() {
+            return 'WP Photo Album Plus';
+        }
+
+        /**
+         * Detect both exact WPPA tables for the current source context.
+         *
+         * Active WPPA constants are authoritative and may intentionally point at
+         * global multisite tables. When WPPA is inactive, only the current site's
+         * prefix is considered.
+         *
+         * @return bool
+         */
+        function detect() {
+            $tables = $this->get_table_names();
+
+            return $this->table_exists( $tables['albums'] ) && $this->table_exists( $tables['photos'] );
+        }
+
+        /**
+         * Find every WPPA album that has at least one migratable image.
+         *
+         * @return array
+         */
+        function find_galleries() {
+            $this->prime_source_data();
+
+            return array_values( $this->galleries_by_id );
+        }
+
+        /**
+         * Flatten WPPA subalbum trees into FooGallery albums containing galleries.
+         *
+         * FooGallery albums cannot contain nested albums. A WPPA album with child
+         * albums therefore becomes one FooGallery album containing its own gallery,
+         * when non-empty, followed by every non-empty descendant gallery.
+         *
+         * @return array
+         */
+        function find_albums() {
+            $this->prime_source_data();
+
+            $albums = array();
+            $children_by_parent = $this->get_album_children();
+
+            foreach ( $this->album_rows as $album_id => $row ) {
+                if ( empty( $children_by_parent[ $album_id ] ) || ! $this->is_public_album( $row ) ) {
+                    continue;
+                }
+
+                $gallery_ids = array();
+                $seen = array();
+                $this->append_descendant_gallery_ids( $album_id, $children_by_parent, $gallery_ids, $seen );
+
+                if ( empty( $gallery_ids ) ) {
+                    continue;
+                }
+
+                $title = isset( $row->name ) ? $row->name : '';
+                $album = $this->get_album(
+                    array(
+                        'ID'             => $album_id,
+                        'title'          => $title,
+                        'data'           => null,
+                        'fooalbum_title' => $title,
+                    )
+                );
+                $album->children = array();
+
+                foreach ( $gallery_ids as $gallery_id ) {
+                    $album->children[] = $this->galleries_by_id[ $gallery_id ];
+                }
+
+                $album->children_count = count( $album->children );
+                $albums[] = $album;
+            }
+
+            return $albums;
+        }
+
+        /**
+         * Return the default FooGallery template.
+         *
+         * @param object $gallery Gallery object.
+         * @return string
+         */
+        function get_gallery_template( $gallery ) {
+            return 'default';
+        }
+
+        /**
+         * Preserve standard title and description caption sources.
+         *
+         * @param object $gallery Gallery object.
+         * @param array  $settings Default settings.
+         * @return array
+         */
+        function get_gallery_settings( $gallery, $settings ) {
+            $template = $this->get_migration_gallery_template( $gallery );
+            $settings = is_array( $settings ) ? $settings : array();
+
+            if ( ! array_key_exists( $template . '_caption_title_source', $settings ) ) {
+                $settings[ $template . '_caption_title_source' ] = 'title';
+            }
+            if ( ! array_key_exists( $template . '_caption_desc_source', $settings ) ) {
+                $settings[ $template . '_caption_desc_source' ] = 'caption';
+            }
+            if ( ! array_key_exists( $template . '_lightbox', $settings ) ) {
+                $settings[ $template . '_lightbox' ] = 'foobox';
+            }
+
+            return $settings;
+        }
+
+        /**
+         * Load a gallery's validated images in deterministic WPPA source order.
+         *
+         * @param object $object Gallery object.
+         * @return array
+         */
+        public function load_object_children( $object ) {
+            if ( ! is_object( $object ) || 'gallery' !== $object->type() ) {
+                return array();
+            }
+
+            $this->prime_source_data();
+            $album_id = absint( $object->ID );
+            if ( ! isset( $this->valid_photos_by_album[ $album_id ] ) ) {
+                return array();
+            }
+
+            $rows = $this->valid_photos_by_album[ $album_id ];
+            $order = $this->get_photo_order( $album_id );
+            $this->sort_photo_rows( $rows, $order );
+
+            $images = array();
+            foreach ( $rows as $row ) {
+                $source = $this->get_local_photo_source( $row );
+                if ( false === $source ) {
+                    continue;
+                }
+
+                $description = isset( $row->description ) ? $row->description : '';
+                $name = isset( $row->name ) ? $row->name : '';
+                $images[] = $this->get_image(
+                    array(
+                        'ID'          => (int) $row->id,
+                        'source_url'  => $source['url'],
+                        'slug'        => $this->image_slug( $row ),
+                        'title'       => $name,
+                        'caption'     => $description,
+                        'description' => $description,
+                        'alt'         => isset( $row->alt ) ? $row->alt : '',
+                        'date'        => $this->get_valid_photo_date( $row ),
+                        'data'        => null,
+                    )
+                );
+            }
+
+            return $images;
+        }
+
+        /**
+         * Match only a single, explicit positive numeric album value.
+         *
+         * Dynamic selectors, names, encrypted IDs and combined expressions are
+         * deliberately left untouched.
+         *
+         * @return array
+         */
+        function get_shortcode_patterns() {
+            return array(
+                '/\[wppa(?=[\s\]])[^\]]*\]/i',
+            );
+        }
+
+        /**
+         * Resolve a shortcode regex match using WPPA's exact album attribute.
+         *
+         * @param array $match Regex match.
+         * @return int|false
+         */
+        function get_content_match_identifier( $match ) {
+            if ( ! is_array( $match ) || ! isset( $match[0] ) ) {
+                return false;
+            }
+            $shortcode = is_array( $match[0] ) && isset( $match[0][0] ) ? $match[0][0] : $match[0];
+            if ( ! is_string( $shortcode ) ) {
+                return false;
+            }
+
+            return $this->get_exact_shortcode_album_id( $shortcode );
+        }
+
+        /**
+         * WPPA block names whose saved content contains a WPPA shortcode.
+         *
+         * @return array
+         */
+        function get_block_patterns() {
+            return array(
+                'wppa/gutenberg-wppa'              => array(),
+                'wp-photo-album-plus/general'      => array(),
+                'wp-photo-album-plus/slideshow'    => array(),
+            );
+        }
+
+        /**
+         * Exact numeric album references map to their corresponding gallery.
+         *
+         * @param string $original_content Original source content.
+         * @param string $block_name Block name.
+         * @return string
+         */
+        function get_content_object_type( $original_content, $block_name = '' ) {
+            return 'gallery';
+        }
+
+        /**
+         * Resolve a WPPA block only from an exact shortcode stored by that block.
+         *
+         * This deliberately bypasses the content migrator's generic ID keys so an
+         * unrelated block attribute cannot turn a dynamic WPPA selector into a
+         * numeric gallery replacement.
+         *
+         * @param array $block Parsed WordPress block.
+         * @return int|false
+         */
+        function get_content_block_identifier( $block ) {
+            $contents = array();
+
+            if ( isset( $block['attrs'] ) && is_array( $block['attrs'] ) ) {
+                foreach ( array( 'wppaShortcode', 'shortcode' ) as $key ) {
+                    if ( isset( $block['attrs'][ $key ] ) && is_string( $block['attrs'][ $key ] ) ) {
+                        $contents[] = $block['attrs'][ $key ];
+                    }
+                }
+            }
+            if ( isset( $block['innerContent'] ) && is_array( $block['innerContent'] ) ) {
+                foreach ( $block['innerContent'] as $content ) {
+                    if ( is_string( $content ) ) {
+                        $contents[] = $content;
+                    }
+                }
+            }
+            if ( isset( $block['innerHTML'] ) && is_string( $block['innerHTML'] ) ) {
+                $contents[] = $block['innerHTML'];
+            }
+
+            $ids = array();
+			$matched_shortcodes = 0;
+            foreach ( $contents as $content ) {
+                foreach ( $this->get_shortcode_patterns() as $pattern ) {
+                    $matches = array();
+                    if ( ! preg_match_all( $pattern, $content, $matches, PREG_SET_ORDER ) ) {
+                        continue;
+                    }
+                    foreach ( $matches as $match ) {
+						++$matched_shortcodes;
+                        $id = $this->get_content_match_identifier( $match );
+						if ( false === $id ) {
+							return false;
+						}
+						$ids[ $id ] = true;
+                    }
+                }
+            }
+
+            if ( 0 === $matched_shortcodes || 1 !== count( $ids ) ) {
+                return false;
+            }
+
+            $ids = array_keys( $ids );
+            return (int) reset( $ids );
+        }
+
+		/**
+		 * Use exact raw occurrences so repeated blocks retain independent offsets.
+		 *
+		 * @return bool
+		 */
+		function uses_exclusive_content_occurrences() {
+			return true;
+		}
+
+		/**
+		 * Find exact WPPA blocks and standalone shortcodes with byte offsets.
+		 *
+		 * @param object $post WordPress post.
+		 * @return array
+		 */
+		function find_content_occurrences( $post ) {
+			$content = isset( $post->post_content ) ? (string) $post->post_content : '';
+			$occurrences = array();
+			$block_ranges = array();
+
+			foreach ( array_keys( $this->get_block_patterns() ) as $block_name ) {
+				$name = preg_quote( $block_name, '/' );
+				$pattern = '/<!--\s+wp:' . $name . '\b(?:(?!-->).)*-->(?:(?!<!--\s+\/wp:' . $name . '\s*-->).)*<!--\s+\/wp:' . $name . '\s*-->/s';
+				$matches = array();
+				if ( ! preg_match_all( $pattern, $content, $matches, PREG_OFFSET_CAPTURE ) ) {
+					continue;
+				}
+				foreach ( $matches[0] as $match ) {
+					$raw = $match[0];
+					$offset = (int) $match[1];
+					$block_ranges[] = array( $offset, $offset + strlen( $raw ) );
+					$block = false;
+					if ( function_exists( 'parse_blocks' ) ) {
+					    $parsed = parse_blocks( $raw );
+					    if ( is_array( $parsed ) && ! empty( $parsed[0] ) ) {
+					        $block = $parsed[0];
+					    }
+					}
+					if ( false === $block ) {
+					    $open = array();
+					    $open_pattern = '/^<!--\s+wp:' . $name . '(?:\s+(.+?))?\s*-->/s';
+					    if ( ! preg_match( $open_pattern, $raw, $open ) ) {
+					        continue;
+					    }
+					    $attrs = isset( $open[1] ) ? json_decode( trim( $open[1] ), true ) : array();
+					    $close_position = strrpos( $raw, '<!--' );
+					    $block = array(
+					        'attrs'        => is_array( $attrs ) ? $attrs : array(),
+					        'innerHTML'    => false !== $close_position ? substr( $raw, strlen( $open[0] ), $close_position - strlen( $open[0] ) ) : '',
+					        'innerContent' => array(),
+					    );
+					}
+					$id = $this->get_content_block_identifier( $block );
+					if ( false !== $id ) {
+						$occurrences[] = array( 'source_id' => $id, 'type' => 'block', 'original_content' => $raw, 'match_offset' => $offset, 'block_name' => $block_name );
+					}
+				}
+			}
+
+			foreach ( $this->get_shortcode_patterns() as $pattern ) {
+				$matches = array();
+				if ( ! preg_match_all( $pattern, $content, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE ) ) {
+					continue;
+				}
+				foreach ( $matches as $match ) {
+					$offset = (int) $match[0][1];
+					$inside_block = false;
+					foreach ( $block_ranges as $range ) {
+						if ( $offset >= $range[0] && $offset < $range[1] ) {
+							$inside_block = true;
+							break;
+						}
+					}
+					if ( $inside_block ) {
+						continue;
+					}
+					$id = $this->get_content_match_identifier( $match );
+					if ( false !== $id ) {
+						$occurrences[] = array( 'source_id' => $id, 'type' => 'shortcode', 'original_content' => $match[0][0], 'match_offset' => $offset );
+					}
+				}
+			}
+
+			usort( $occurrences, function( $left, $right ) { return $left['match_offset'] - $right['match_offset']; } );
+			return $occurrences;
+		}
+
+        /**
+         * Parse a WPPA shortcode without accepting album-like text in another
+         * attribute or a prefixed attribute such as data-album.
+         *
+         * @param string $shortcode Complete shortcode.
+         * @return int|false
+         */
+        private function get_exact_shortcode_album_id( $shortcode ) {
+            if ( ! is_string( $shortcode ) || ! preg_match( '/^\[wppa(?=[\s\]])/i', $shortcode ) || ']' !== substr( $shortcode, -1 ) ) {
+                return false;
+            }
+
+            $attributes = substr( $shortcode, 5, -1 );
+            $length = strlen( $attributes );
+            $position = 0;
+            $album_id = false;
+            $album_count = 0;
+
+            while ( $position < $length ) {
+                while ( $position < $length && ctype_space( $attributes[ $position ] ) ) {
+                    ++$position;
+                }
+                if ( $position >= $length ) {
+                    break;
+                }
+
+                $name_start = $position;
+                while ( $position < $length && preg_match( '/[A-Za-z0-9_:\-]/', $attributes[ $position ] ) ) {
+                    ++$position;
+                }
+                if ( $name_start === $position ) {
+                    return false;
+                }
+                $name = strtolower( substr( $attributes, $name_start, $position - $name_start ) );
+
+                while ( $position < $length && ctype_space( $attributes[ $position ] ) ) {
+                    ++$position;
+                }
+                if ( $position >= $length || '=' !== $attributes[ $position ] ) {
+                    continue;
+                }
+                ++$position;
+                while ( $position < $length && ctype_space( $attributes[ $position ] ) ) {
+                    ++$position;
+                }
+                if ( $position >= $length ) {
+                    return false;
+                }
+
+                $quote = $attributes[ $position ];
+                if ( '"' === $quote || "'" === $quote ) {
+                    ++$position;
+                    $value_start = $position;
+                    while ( $position < $length && $quote !== $attributes[ $position ] ) {
+                        ++$position;
+                    }
+                    if ( $position >= $length ) {
+                        return false;
+                    }
+                    $value = substr( $attributes, $value_start, $position - $value_start );
+                    ++$position;
+                } else {
+                    $value_start = $position;
+                    while ( $position < $length && ! ctype_space( $attributes[ $position ] ) ) {
+                        ++$position;
+                    }
+                    $value = substr( $attributes, $value_start, $position - $value_start );
+                }
+
+                if ( 'album' === $name ) {
+                    ++$album_count;
+                    if ( 1 !== $album_count || ! preg_match( '/^[1-9]\d*$/', $value ) ) {
+                        return false;
+                    }
+                    $album_id = (int) $value;
+                }
+            }
+
+            return 1 === $album_count ? $album_id : false;
+        }
+
+        /**
+         * Prime albums, photos and gallery candidates once per request.
+         *
+         * @return void
+         */
+        private function prime_source_data() {
+            if ( null !== $this->galleries_by_id ) {
+                return;
+            }
+
+            $this->album_rows = array();
+            $this->photo_rows = array();
+            $this->valid_photos_by_album = array();
+            $this->galleries_by_id = array();
+
+            if ( ! $this->detect() ) {
+                return;
+            }
+
+            global $wpdb;
+            $tables = $this->get_table_names();
+            if ( ! $this->is_safe_table_name( $tables['albums'] ) || ! $this->is_safe_table_name( $tables['photos'] ) ) {
+                return;
+            }
+
+            $album_rows = $wpdb->get_results(
+                "SELECT id, name, description, a_order, a_parent, p_order_by, suba_order_by, timestamp, status, capability
+                FROM {$tables['albums']}
+                ORDER BY a_order ASC, id ASC"
+            );
+            $photo_rows = $wpdb->get_results(
+                "SELECT id, album, ext, name, description, p_order, mean_rating, rating_count,
+                    owner, timestamp, status, alt, filename, modified, exifdtm,
+                    videox, videoy, duration, misc
+                FROM {$tables['photos']}
+                WHERE album > 0
+                ORDER BY id ASC"
+            );
+
+            $album_rows = is_array( $album_rows ) ? $album_rows : array();
+            $photo_rows = is_array( $photo_rows ) ? $photo_rows : array();
+
+            foreach ( $album_rows as $row ) {
+                $album_id = isset( $row->id ) ? (int) $row->id : 0;
+                if ( $album_id > 0 ) {
+                    $this->album_rows[ $album_id ] = $row;
+                }
+            }
+
+            foreach ( $photo_rows as $row ) {
+                $album_id = isset( $row->album ) ? (int) $row->album : 0;
+                if ( $album_id < 1 || ! isset( $this->album_rows[ $album_id ] ) ) {
+                    continue;
+                }
+                if ( ! $this->is_public_album( $this->album_rows[ $album_id ] ) || ! $this->is_migratable_photo( $row ) ) {
+                    continue;
+                }
+
+                if ( ! isset( $this->valid_photos_by_album[ $album_id ] ) ) {
+                    $this->valid_photos_by_album[ $album_id ] = array();
+                }
+                $this->valid_photos_by_album[ $album_id ][] = $row;
+                $this->photo_rows[ (int) $row->id ] = $row;
+            }
+
+            foreach ( $this->album_rows as $album_id => $row ) {
+                if ( empty( $this->valid_photos_by_album[ $album_id ] ) ) {
+                    continue;
+                }
+
+                $title = isset( $row->name ) ? $row->name : '';
+                $this->galleries_by_id[ $album_id ] = $this->get_gallery(
+                    array(
+                        'ID'             => $album_id,
+                        'title'          => $title,
+                        'data'           => null,
+                        'children'       => array(),
+                        'children_count' => count( $this->valid_photos_by_album[ $album_id ] ),
+                        'settings'       => array(),
+                    )
+                );
+            }
+        }
+
+        /**
+         * Resolve authoritative active table constants or current-site inactive tables.
+         *
+         * @return array
+         */
+        private function get_table_names() {
+            global $wpdb;
+
+            return array(
+                'albums' => defined( 'WPPA_ALBUMS' ) ? WPPA_ALBUMS : $wpdb->prefix . 'wppa_albums',
+                'photos' => defined( 'WPPA_PHOTOS' ) ? WPPA_PHOTOS : $wpdb->prefix . 'wppa_photos',
+            );
+        }
+
+        /**
+         * Test a literal table name without allowing LIKE metacharacters to expand.
+         *
+         * @param string $table Table name.
+         * @return bool
+         */
+        private function table_exists( $table ) {
+            global $wpdb;
+
+            if ( ! $this->is_safe_table_name( $table ) ) {
+                return false;
+            }
+
+            $escaped = method_exists( $wpdb, 'esc_like' ) ? $wpdb->esc_like( $table ) : addcslashes( $table, '_%\\' );
+            $found = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $escaped ) );
+
+            return is_string( $found ) && $found === $table;
+        }
+
+        /**
+         * Restrict interpolated identifiers to WordPress-compatible table names.
+         *
+         * @param string $table Table name.
+         * @return bool
+         */
+        private function is_safe_table_name( $table ) {
+            return is_string( $table ) && 1 === preg_match( '/^[A-Za-z0-9_]+$/', $table );
+        }
+
+        /**
+         * Determine whether an album is public/displayable.
+         *
+         * @param object $row Album row.
+         * @return bool
+         */
+        private function is_public_album( $row ) {
+            $status = isset( $row->status ) ? strtolower( trim( $row->status ) ) : '';
+            $capability = isset( $row->capability ) ? trim( (string) $row->capability ) : '';
+
+            return '' === $capability && 'publish' === $status;
+        }
+
+        /**
+         * Validate status, media type and canonical local display file.
+         *
+         * @param object $row Photo row.
+         * @return bool
+         */
+        private function is_migratable_photo( $row ) {
+            $id = isset( $row->id ) ? (int) $row->id : 0;
+            $album_id = isset( $row->album ) ? (int) $row->album : 0;
+            $status = isset( $row->status ) ? strtolower( trim( $row->status ) ) : '';
+            $ext = isset( $row->ext ) ? strtolower( trim( $row->ext ) ) : '';
+
+            if ( $id < 1 || $album_id < 1 ) {
+                return false;
+            }
+            if ( ! in_array( $status, array( 'publish', 'featured', 'gold', 'silver', 'bronze' ), true ) ) {
+                return false;
+            }
+            if ( ! in_array( $ext, array( 'jpg', 'jpeg', 'png', 'gif', 'webp' ), true ) ) {
+                return false;
+            }
+
+            return false !== $this->get_local_photo_source( $row );
+        }
+
+        /**
+         * Build and verify a canonical flat/tree local WPPA image path and URL.
+         *
+         * @param object $row Photo row.
+         * @return array|false
+         */
+        private function get_local_photo_source( $row ) {
+            $id = isset( $row->id ) ? (int) $row->id : 0;
+            $ext = isset( $row->ext ) ? strtolower( trim( $row->ext ) ) : '';
+            if ( $id < 1 || ! in_array( $ext, array( 'jpg', 'jpeg', 'png', 'gif', 'webp' ), true ) ) {
+                return false;
+            }
+
+            $locations = $this->get_upload_locations();
+            if ( false === $locations ) {
+                return false;
+            }
+
+            $relative = (string) $id;
+            if ( 'tree' === get_option( 'wppa_file_system', 'flat' ) ) {
+                $relative = $this->expand_photo_id( $id );
+            }
+            $relative .= '.' . $ext;
+
+            $base_path = rtrim( wp_normalize_path( $locations['path'] ), '/' );
+            $path = wp_normalize_path( $base_path . '/' . $relative );
+            $real_base = realpath( $base_path );
+            $real_path = realpath( $path );
+            if ( false === $real_base || false === $real_path ) {
+                return false;
+            }
+            $real_base = rtrim( wp_normalize_path( $real_base ), '/' );
+            $real_path = wp_normalize_path( $real_path );
+            if ( 0 !== strpos( $real_path, $real_base . '/' ) || ! is_file( $real_path ) ) {
+                return false;
+            }
+
+            $image_types = array(
+                'gif'  => IMAGETYPE_GIF,
+                'jpg'  => IMAGETYPE_JPEG,
+                'jpeg' => IMAGETYPE_JPEG,
+                'png'  => IMAGETYPE_PNG,
+            );
+            if ( defined( 'IMAGETYPE_WEBP' ) ) {
+                $image_types['webp'] = IMAGETYPE_WEBP;
+            }
+            $image_info = @getimagesize( $real_path );
+            if ( ! isset( $image_types[ $ext ] ) || ! is_array( $image_info ) || ! isset( $image_info[2] ) || $image_types[ $ext ] !== (int) $image_info[2] ) {
+                return false;
+            }
+
+            return array(
+                'path' => $real_path,
+                'url'  => rtrim( $locations['url'], '/' ) . '/' . str_replace( '%2F', '/', rawurlencode( $relative ) ),
+            );
+        }
+
+        /**
+         * Resolve active WPPA locations, otherwise current-site uploads only.
+         *
+         * @return array|false
+         */
+        private function get_upload_locations() {
+            if ( defined( 'WPPA_UPLOAD_PATH' ) && defined( 'WPPA_UPLOAD_URL' ) ) {
+                $path = WPPA_UPLOAD_PATH;
+                $url = WPPA_UPLOAD_URL;
+            } else {
+                $uploads = wp_get_upload_dir();
+                if ( ! is_array( $uploads ) || empty( $uploads['basedir'] ) || empty( $uploads['baseurl'] ) ) {
+                    return false;
+                }
+                $path = rtrim( $uploads['basedir'], '/\\' ) . '/wppa';
+                $url = rtrim( $uploads['baseurl'], '/' ) . '/wppa';
+            }
+
+            if ( ! is_string( $path ) || '' === $path || ! is_string( $url ) || '' === $url ) {
+                return false;
+            }
+
+            return array( 'path' => $path, 'url' => $url );
+        }
+
+        /**
+         * Mirror WPPA's two-digit tree expansion without creating directories.
+         *
+         * @param int $id Photo ID.
+         * @return string
+         */
+        private function expand_photo_id( $id ) {
+            $remaining = (string) absint( $id );
+            $parts = array();
+
+            while ( strlen( $remaining ) > 2 ) {
+                $parts[] = substr( $remaining, 0, 2 );
+                $remaining = substr( $remaining, 2 );
+            }
+            $parts[] = $remaining;
+
+            return implode( '/', $parts );
+        }
+
+        /**
+         * Return per-album order, falling back to WPPA's global option.
+         *
+         * @param int $album_id Album ID.
+         * @return int
+         */
+        private function get_photo_order( $album_id ) {
+            $order = isset( $this->album_rows[ $album_id ]->p_order_by ) ? (int) $this->album_rows[ $album_id ]->p_order_by : 0;
+            if ( 0 === $order ) {
+                $order = (int) get_option( 'wppa_list_photos_by', 0 );
+            }
+
+            return $order;
+        }
+
+        /**
+         * Sort supported WPPA order modes with an ascending ID tie-breaker.
+         *
+         * Random and unknown modes intentionally fall back to ID ascending.
+         *
+         * @param array $rows Photo rows.
+         * @param int   $order WPPA order value.
+         * @return void
+         */
+        private function sort_photo_rows( &$rows, $order ) {
+            $field_map = array(
+                1 => 'p_order',
+                2 => 'name',
+                4 => 'mean_rating',
+                5 => 'timestamp',
+                6 => 'rating_count',
+                7 => 'exifdtm',
+            );
+            $absolute = abs( (int) $order );
+            $field = isset( $field_map[ $absolute ] ) ? $field_map[ $absolute ] : 'id';
+            $direction = ( (int) $order < 0 && 'id' !== $field ) ? -1 : 1;
+
+            usort(
+                $rows,
+                function( $left, $right ) use ( $field, $direction ) {
+                    $left_value = isset( $left->{$field} ) ? $left->{$field} : '';
+                    $right_value = isset( $right->{$field} ) ? $right->{$field} : '';
+
+                    if ( in_array( $field, array( 'p_order', 'mean_rating', 'rating_count', 'id' ), true ) ) {
+                        $comparison = (float) $left_value == (float) $right_value ? 0 : ( (float) $left_value < (float) $right_value ? -1 : 1 );
+                    } else {
+                        $comparison = strcasecmp( (string) $left_value, (string) $right_value );
+                    }
+
+                    if ( 0 !== $comparison ) {
+                        return $comparison * $direction;
+                    }
+
+                    $left_id = isset( $left->id ) ? (int) $left->id : 0;
+                    $right_id = isset( $right->id ) ? (int) $right->id : 0;
+                    if ( $left_id === $right_id ) {
+                        return 0;
+                    }
+
+                    return $left_id < $right_id ? -1 : 1;
+                }
+            );
+        }
+
+        /**
+         * Build public album child lists in deterministic source order.
+         *
+         * @return array
+         */
+        private function get_album_children() {
+            $children = array();
+
+            foreach ( $this->album_rows as $album_id => $row ) {
+                if ( ! $this->is_public_album( $row ) ) {
+                    continue;
+                }
+                $parent_id = isset( $row->a_parent ) ? (int) $row->a_parent : 0;
+                if ( $parent_id > 0 && isset( $this->album_rows[ $parent_id ] ) ) {
+                    if ( ! isset( $children[ $parent_id ] ) ) {
+                        $children[ $parent_id ] = array();
+                    }
+                    $children[ $parent_id ][] = $album_id;
+                }
+            }
+
+            foreach ( $children as $parent_id => &$ids ) {
+                $parent = $this->album_rows[ $parent_id ];
+                $order = isset( $parent->suba_order_by ) ? (int) $parent->suba_order_by : 0;
+                if ( 0 === $order ) {
+                    $order = (int) get_option( 'wppa_list_albums_by', 0 );
+                }
+                $field_map = array( 1 => 'a_order', 2 => 'name', 5 => 'timestamp' );
+                $absolute = abs( $order );
+                $field = isset( $field_map[ $absolute ] ) ? $field_map[ $absolute ] : 'id';
+                $direction = ( $order < 0 && 'id' !== $field ) ? -1 : 1;
+                usort(
+                    $ids,
+                    function( $left_id, $right_id ) use ( $field, $direction ) {
+                        $left = $this->album_rows[ $left_id ];
+                        $right = $this->album_rows[ $right_id ];
+                        $left_value = isset( $left->{$field} ) ? $left->{$field} : '';
+                        $right_value = isset( $right->{$field} ) ? $right->{$field} : '';
+
+                        if ( in_array( $field, array( 'a_order', 'id' ), true ) ) {
+                            $comparison = (int) $left_value === (int) $right_value ? 0 : ( (int) $left_value < (int) $right_value ? -1 : 1 );
+                        } else {
+                            $comparison = strcasecmp( (string) $left_value, (string) $right_value );
+                        }
+
+                        if ( 0 !== $comparison ) {
+                            return $comparison * $direction;
+                        }
+
+                        return $left_id < $right_id ? -1 : ( $left_id === $right_id ? 0 : 1 );
+                    }
+                );
+            }
+            unset( $ids );
+
+            return $children;
+        }
+
+        /**
+         * Append a source album's own gallery and all descendant galleries once.
+         *
+         * @param int   $album_id Source album ID.
+         * @param array $children_by_parent Child lookup.
+         * @param array $gallery_ids Result IDs.
+         * @param array $seen Cycle/deduplication guard.
+         * @return void
+         */
+        private function append_descendant_gallery_ids( $album_id, $children_by_parent, &$gallery_ids, &$seen ) {
+            if ( isset( $seen[ $album_id ] ) ) {
+                return;
+            }
+            $seen[ $album_id ] = true;
+
+            if ( isset( $this->galleries_by_id[ $album_id ] ) ) {
+                $gallery_ids[] = $album_id;
+            }
+
+            if ( empty( $children_by_parent[ $album_id ] ) ) {
+                return;
+            }
+
+            foreach ( $children_by_parent[ $album_id ] as $child_id ) {
+                $this->append_descendant_gallery_ids( $child_id, $children_by_parent, $gallery_ids, $seen );
+            }
+        }
+
+        /**
+         * Use source filename only as metadata after reducing it to a basename.
+         *
+         * @param object $row Photo row.
+         * @return string
+         */
+        private function image_slug( $row ) {
+            $filename = isset( $row->filename ) ? basename( str_replace( '\\', '/', $row->filename ) ) : '';
+            if ( '' !== $filename ) {
+                return pathinfo( $filename, PATHINFO_FILENAME );
+            }
+
+            return isset( $row->name ) ? $row->name : (string) $row->id;
+        }
+
+        /**
+         * Preserve the first valid EXIF, upload or modified date.
+         *
+         * @param object $row Photo row.
+         * @return string
+         */
+        private function get_valid_photo_date( $row ) {
+            foreach ( array( 'exifdtm', 'timestamp', 'modified' ) as $field ) {
+                if ( ! isset( $row->{$field} ) || '' === trim( (string) $row->{$field} ) ) {
+                    continue;
+                }
+
+                $value = trim( (string) $row->{$field} );
+                foreach ( array( 'Y-m-d H:i:s', 'Y:m:d H:i:s' ) as $format ) {
+                    $date = \DateTime::createFromFormat( '!' . $format, $value );
+                    $errors = \DateTime::getLastErrors();
+                    $is_valid = false !== $date && ( false === $errors || ( 0 === $errors['warning_count'] && 0 === $errors['error_count'] ) );
+                    if ( $is_valid && $date->format( $format ) === $value ) {
+                        return $date->format( 'Y-m-d H:i:s' );
+                    }
+                }
+                if ( ctype_digit( $value ) && (int) $value > 0 ) {
+                    return date( 'Y-m-d H:i:s', (int) $value );
+                }
+            }
+
+            return '';
+        }
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,7 @@ Migrate to FooGallery from other gallery plugins, including:
 *	Photo Gallery by 10Web
 *	Robo Gallery
 *	Album and Image Gallery Plus Lightbox (plugin was closed Apr 2026 due to being compromised)
+*	WP Photo Album Plus
 *	Built-in WordPress Gallery blocks and [gallery] shortcodes
 
 Features:
@@ -57,6 +58,16 @@ FooGallery free has 7 gallery styles and a load of different settings to customi
 = Migrate Away From "Album and Image Gallery Plus Lightbox" =
 
 FooGallery Migrate can detect "Album and Image Gallery Plus Lightbox" galleries directly from WordPress database records, so the source plugin does not need to be active or loaded during migration.
+
+= Migrate Away From "WP Photo Album Plus" =
+
+FooGallery Migrate detects the exact current-site WP Photo Album Plus database tables even when WP Photo Album Plus is inactive. It creates one FooGallery gallery for each source album containing a supported, public local image and preserves image titles, descriptions/captions, alternative text, valid dates and deterministic source order.
+
+WP Photo Album Plus stores images outside the WordPress Media Library. FooGallery Migrate supports its current flat and tree upload layouts and imports canonical local JPG, JPEG, PNG, GIF and WebP display files. WebP files require image inspection support in the site's PHP runtime; when unavailable they are skipped safely. Missing or malformed files, invalid rows, trashed/deleted items, capability-restricted albums, non-public or unknown statuses, and video, audio, PDF or other unsupported payloads are skipped rather than creating broken attachments.
+
+Nested WP Photo Album Plus albums cannot be represented exactly because FooGallery albums contain galleries, not other albums. A source album with child albums is therefore offered as a FooGallery album containing its own non-empty gallery and all non-empty descendant galleries in a flattened list. Empty branches are omitted.
+
+Only WP Photo Album Plus shortcodes and blocks containing one explicit positive numeric `album` value can be replaced automatically. Dynamic or virtual expressions (including names, encrypted IDs, `#last`, tag/search/query selectors and combined album expressions) are intentionally left unchanged for manual review. Random or unknown WP Photo Album Plus image order is converted to stable source-ID order; supported configured order modes use source IDs as deterministic tie-breakers.
 
 == Installation ==
 

--- a/tests/WpPhotoAlbumPlusPluginTest.php
+++ b/tests/WpPhotoAlbumPlusPluginTest.php
@@ -2,6 +2,7 @@
 
 namespace FooPlugins\FooGalleryMigrate\Tests;
 
+use FooPlugins\FooGalleryMigrate\Init;
 use FooPlugins\FooGalleryMigrate\MigratorEngine;
 use FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator;
 use FooPlugins\FooGalleryMigrate\Objects\Album;
@@ -45,6 +46,34 @@ class WpPhotoAlbumPlusPluginTest extends TestCase {
 		$this->assertStringContainsString( 'new \\FooPlugins\\FooGalleryMigrate\\Plugins\\WpPhotoAlbumPlus()', $registry_source );
 	}
 
+	public function test_ajax_title_lookup_accepts_php_normalized_wppa_field_names(): void {
+		parse_str(
+			http_build_query( array( 'foogallery-title-gallery_WP Photo Album Plus_4' => 'Renamed WPPA Gallery' ) ),
+			$_POST
+		);
+		$init = ( new \ReflectionClass( Init::class ) )->newInstanceWithoutConstructor();
+		$method = new \ReflectionMethod( $init, 'get_migration_title_from_request' );
+
+		$this->assertSame(
+			'Renamed WPPA Gallery',
+			$method->invoke( $init, 'gallery_WP Photo Album Plus_4' )
+		);
+	}
+
+	public function test_ajax_album_title_lookup_accepts_php_normalized_wppa_field_names(): void {
+		parse_str(
+			http_build_query( array( 'foogallery-album-title-album_WP Photo Album Plus_3' => 'Renamed WPPA Album' ) ),
+			$_POST
+		);
+		$init = ( new \ReflectionClass( Init::class ) )->newInstanceWithoutConstructor();
+		$method = new \ReflectionMethod( $init, 'get_migration_title_from_request' );
+
+		$this->assertSame(
+			'Renamed WPPA Album',
+			$method->invoke( $init, 'album_WP Photo Album Plus_3', 'foogallery-album-title-' )
+		);
+	}
+
 	public function test_detection_requires_both_exact_current_site_tables_when_inactive(): void {
 		$plugin = new WpPhotoAlbumPlus();
 		$wpdb = $GLOBALS['wpdb'];
@@ -81,7 +110,7 @@ class WpPhotoAlbumPlusPluginTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_active_wppa_upload_constants_are_used_for_local_sources(): void {
-		$upload_path = '/home/brad/.cache/wppa-active-upload-test';
+		$upload_path = $this->test_upload_dir() . '/wppa-active-upload-test';
 		define( 'WPPA_ALBUMS', 'network_wppa_albums' );
 		define( 'WPPA_PHOTOS', 'network_wppa_photos' );
 		define( 'WPPA_UPLOAD_PATH', $upload_path );
@@ -90,7 +119,7 @@ class WpPhotoAlbumPlusPluginTest extends TestCase {
 			mkdir( $upload_path, 0777, true );
 		}
 		$this->create_photo_file( '601.jpg' );
-		file_put_contents( $upload_path . '/601.jpg', file_get_contents( '/tmp/uploads/wppa/601.jpg' ) );
+		file_put_contents( $upload_path . '/601.jpg', file_get_contents( $this->test_upload_dir() . '/wppa/601.jpg' ) );
 
 		$GLOBALS['foogallery_migrate_test_options'] = array( 'wppa_file_system' => 'flat' );
 		$GLOBALS['foogallery_migrate_engine_instance'] = new MigratorEngine();
@@ -151,13 +180,15 @@ class WpPhotoAlbumPlusPluginTest extends TestCase {
 		$this->create_photo_file( '112.jpg' );
 		$this->create_photo_file( '801.jpg' );
 		$this->create_photo_file( '901.jpg' );
-		$malformed_file = '/tmp/uploads/wppa/113.jpg';
+		$wppa_directory = $this->test_upload_dir() . '/wppa';
+		$malformed_file = $wppa_directory . '/113.jpg';
 		file_put_contents( $malformed_file, 'not an image' );
 		$this->created_files[] = $malformed_file;
-		$outside_file = '/home/brad/.cache/wppa-outside-image.jpg';
+		$outside_file = dirname( $this->test_upload_dir() ) . '/wppa-outside-image.jpg';
+		$escaped_symlink = $wppa_directory . '/111.jpg';
 		file_put_contents( $outside_file, 'outside synthetic fixture' );
-		symlink( $outside_file, '/tmp/uploads/wppa/111.jpg' );
-		$this->created_files[] = '/tmp/uploads/wppa/111.jpg';
+		symlink( $outside_file, $escaped_symlink );
+		$this->created_files[] = $escaped_symlink;
 		$this->created_files[] = $outside_file;
 
 		$galleries = $plugin->find_galleries();
@@ -454,7 +485,7 @@ class WpPhotoAlbumPlusPluginTest extends TestCase {
 	}
 
 	private function create_photo_file( string $relative_path ): void {
-		$file = '/tmp/uploads/wppa/' . $relative_path;
+		$file = $this->test_upload_dir() . '/wppa/' . $relative_path;
 		$directory = dirname( $file );
 		if ( ! is_dir( $directory ) ) {
 			mkdir( $directory, 0777, true );
@@ -470,6 +501,15 @@ class WpPhotoAlbumPlusPluginTest extends TestCase {
 		$data = isset( $fixtures[ $extension ] ) ? base64_decode( $fixtures[ $extension ] ) : 'synthetic non-image fixture';
 		file_put_contents( $file, $data );
 		$this->created_files[] = $file;
+	}
+
+	private function test_upload_dir(): string {
+		$environment_basedir = getenv( 'FOOGALLERY_MIGRATE_TEST_UPLOAD_DIR' );
+		$basedir = isset( $GLOBALS['foogallery_migrate_test_upload_dir'] )
+			? $GLOBALS['foogallery_migrate_test_upload_dir']
+			: ( is_string( $environment_basedir ) && '' !== $environment_basedir ? $environment_basedir : '/tmp/uploads' );
+
+		return rtrim( (string) $basedir, '/\\' );
 	}
 
 	private function extract_shortcode_id( string $content, WpPhotoAlbumPlus $plugin ) {

--- a/tests/WpPhotoAlbumPlusPluginTest.php
+++ b/tests/WpPhotoAlbumPlusPluginTest.php
@@ -1,0 +1,551 @@
+<?php
+
+namespace FooPlugins\FooGalleryMigrate\Tests;
+
+use FooPlugins\FooGalleryMigrate\MigratorEngine;
+use FooPlugins\FooGalleryMigrate\Migrators\ContentMigrator;
+use FooPlugins\FooGalleryMigrate\Objects\Album;
+use FooPlugins\FooGalleryMigrate\Objects\Gallery;
+use FooPlugins\FooGalleryMigrate\Plugins\WpPhotoAlbumPlus;
+use PHPUnit\Framework\TestCase;
+
+class WpPhotoAlbumPlusPluginTest extends TestCase {
+
+	private $created_files = array();
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$GLOBALS['foogallery_migrate_test_options'] = array();
+		$GLOBALS['foogallery_migrate_test_plugins'] = array();
+		$GLOBALS['foogallery_migrate_test_posts'] = array();
+		$GLOBALS['foogallery_migrate_test_post_meta'] = array();
+		$GLOBALS['foogallery_migrate_test_imported_attachments'] = array();
+		$GLOBALS['foogallery_migrate_test_attachment_url_to_postid'] = array();
+		$GLOBALS['foogallery_migrate_engine_instance'] = new MigratorEngine();
+		$GLOBALS['wpdb'] = new FakeWpPhotoAlbumPlusWpdb();
+	}
+
+	protected function tearDown(): void {
+		foreach ( array_reverse( $this->created_files ) as $file ) {
+			if ( is_file( $file ) || is_link( $file ) ) {
+				unlink( $file );
+			}
+		}
+		$this->created_files = array();
+
+		parent::tearDown();
+	}
+
+	public function test_source_is_registered_with_exact_name(): void {
+		$plugin = new WpPhotoAlbumPlus();
+		$registry_source = file_get_contents( FOOGM_DIR . '/includes/functions.php' );
+
+		$this->assertSame( 'WP Photo Album Plus', $plugin->name() );
+		$this->assertStringContainsString( 'new \\FooPlugins\\FooGalleryMigrate\\Plugins\\WpPhotoAlbumPlus()', $registry_source );
+	}
+
+	public function test_detection_requires_both_exact_current_site_tables_when_inactive(): void {
+		$plugin = new WpPhotoAlbumPlus();
+		$wpdb = $GLOBALS['wpdb'];
+
+		$wpdb->tables = array( 'wp_wppa_albums_backup', 'wp_wppa_photos_old' );
+		$this->assertFalse( $plugin->detect(), 'LIKE wildcard lookalikes must not be detected.' );
+
+		$wpdb->tables = array( 'wp_wppa_albums', 'wp_wppa_photos' );
+		$wpdb->table_detection_arguments = array();
+		$this->assertTrue( $plugin->detect() );
+		$this->assertSame( array( 'wp_wppa_albums', 'wp_wppa_photos' ), $wpdb->table_detection_arguments );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_detection_honors_active_wppa_table_constants(): void {
+		define( 'WPPA_ALBUMS', 'network_wppa_albums' );
+		define( 'WPPA_PHOTOS', 'network_wppa_photos' );
+
+		$GLOBALS['wpdb'] = new FakeWpPhotoAlbumPlusWpdb();
+		$GLOBALS['wpdb']->prefix = 'wp_9_';
+		$GLOBALS['wpdb']->tables = array( 'network_wppa_albums', 'network_wppa_photos' );
+
+		$plugin = new WpPhotoAlbumPlus();
+
+		$this->assertTrue( $plugin->detect() );
+		$this->assertSame( array( 'network_wppa_albums', 'network_wppa_photos' ), $GLOBALS['wpdb']->table_detection_arguments );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_active_wppa_upload_constants_are_used_for_local_sources(): void {
+		$upload_path = '/home/brad/.cache/wppa-active-upload-test';
+		define( 'WPPA_ALBUMS', 'network_wppa_albums' );
+		define( 'WPPA_PHOTOS', 'network_wppa_photos' );
+		define( 'WPPA_UPLOAD_PATH', $upload_path );
+		define( 'WPPA_UPLOAD_URL', 'https://media.example.test/wppa' );
+		if ( ! is_dir( $upload_path ) ) {
+			mkdir( $upload_path, 0777, true );
+		}
+		$this->create_photo_file( '601.jpg' );
+		file_put_contents( $upload_path . '/601.jpg', file_get_contents( '/tmp/uploads/wppa/601.jpg' ) );
+
+		$GLOBALS['foogallery_migrate_test_options'] = array( 'wppa_file_system' => 'flat' );
+		$GLOBALS['foogallery_migrate_engine_instance'] = new MigratorEngine();
+		$GLOBALS['wpdb'] = new FakeWpPhotoAlbumPlusWpdb();
+		$GLOBALS['wpdb']->tables = array( 'network_wppa_albums', 'network_wppa_photos' );
+		$GLOBALS['wpdb']->albums = array( $this->album( 60, 'Active', '', 0, 1, 1 ) );
+		$GLOBALS['wpdb']->photos = array( $this->photo( 601, 60, 'jpg', 'Active photo', '', 1 ) );
+
+		$plugin = new WpPhotoAlbumPlus();
+		$gallery = $plugin->find_galleries()[0];
+		$images = $plugin->load_object_children( $gallery );
+
+		$this->assertSame( 'https://media.example.test/wppa/601.jpg', $images[0]->source_url );
+
+		unlink( $upload_path . '/601.jpg' );
+		rmdir( $upload_path );
+	}
+
+	public function test_flat_gallery_preserves_metadata_order_and_skips_non_public_or_invalid_payloads(): void {
+		$plugin = new WpPhotoAlbumPlus();
+		$wpdb = $GLOBALS['wpdb'];
+		$wpdb->tables = array( 'wp_wppa_albums', 'wp_wppa_photos' );
+		$wpdb->albums = array(
+			$this->album( 7, 'Summer', 'Album description', 0, 1, 1 ),
+			$this->album( 8, 'Restricted', '', 0, 2, 1 ),
+			$this->album( 9, 'Unknown visibility', '', 0, 3, 1 ),
+		);
+		$wpdb->albums[1]->capability = 'edit_private_posts';
+		$wpdb->albums[2]->status = 'mystery';
+		$wpdb->photos = array(
+			$this->photo( 102, 7, 'jpg', 'Second', 'Second caption', 2, 'publish', 'Second alt', '2026-06-02 11:00:00' ),
+			$this->photo( 101, 7, 'png', 'First', 'First caption', 1, 'publish', 'First alt', '2026-06-01 10:00:00' ),
+			$this->photo( 103, 7, 'gif', 'Tie', 'Tie caption', 1, 'publish', 'Tie alt', '2026-02-31 12:00:00' ),
+			$this->photo( 104, 7, 'jpg', 'Pending', '', 0, 'pending' ),
+			$this->photo( 105, 7, 'jpg', 'Scheduled', '', 0, 'scheduled' ),
+			$this->photo( 106, 7, 'jpg', 'Private', '', 0, 'private' ),
+			$this->photo( 107, -7, 'jpg', 'Trashed', '', 0, '' ),
+			$this->photo( 108, 7, 'mp4', 'Video', '', 0, '' ),
+			$this->photo( 109, 7, '../jpg', 'Traversal', '', 0, '' ),
+			$this->photo( 110, 7, 'webp', 'Missing', '', 0, '' ),
+			$this->photo( 111, 7, 'jpg', 'Escaped symlink', '', 0, '' ),
+			$this->photo( 112, 7, 'jpg', 'Unknown status', '', 0, 'mystery' ),
+			$this->photo( 113, 7, 'jpg', 'Malformed image', '', 0, 'publish' ),
+			$this->photo( 801, 8, 'jpg', 'Restricted photo', '', 1, 'publish' ),
+			$this->photo( 901, 9, 'jpg', 'Unknown album photo', '', 1, 'publish' ),
+		);
+		$wpdb->photos[1]->exifdtm = '2026:05:31 09:08:07';
+		$GLOBALS['foogallery_migrate_test_options']['wppa_file_system'] = 'flat';
+
+		$this->create_photo_file( '101.png' );
+		$this->create_photo_file( '102.jpg' );
+		$this->create_photo_file( '103.gif' );
+		$this->create_photo_file( '104.jpg' );
+		$this->create_photo_file( '105.jpg' );
+		$this->create_photo_file( '106.jpg' );
+		$this->create_photo_file( '107.jpg' );
+		$this->create_photo_file( '108.mp4' );
+		$this->create_photo_file( '112.jpg' );
+		$this->create_photo_file( '801.jpg' );
+		$this->create_photo_file( '901.jpg' );
+		$malformed_file = '/tmp/uploads/wppa/113.jpg';
+		file_put_contents( $malformed_file, 'not an image' );
+		$this->created_files[] = $malformed_file;
+		$outside_file = '/home/brad/.cache/wppa-outside-image.jpg';
+		file_put_contents( $outside_file, 'outside synthetic fixture' );
+		symlink( $outside_file, '/tmp/uploads/wppa/111.jpg' );
+		$this->created_files[] = '/tmp/uploads/wppa/111.jpg';
+		$this->created_files[] = $outside_file;
+
+		$galleries = $plugin->find_galleries();
+		$this->assertCount( 1, $galleries );
+		$this->assertInstanceOf( Gallery::class, $galleries[0] );
+		$this->assertSame( 7, (int) $galleries[0]->ID );
+		$this->assertSame( 'Summer', $galleries[0]->title );
+		$this->assertSame( 3, $galleries[0]->children_count );
+
+		$images = $plugin->load_object_children( $galleries[0] );
+		$this->assertSame( array( 101, 103, 102 ), array_map( array( $this, 'object_id' ), $images ) );
+		$this->assertSame( 'First', $images[0]->title );
+		$this->assertSame( 'First caption', $images[0]->caption );
+		$this->assertSame( 'First caption', $images[0]->description );
+		$this->assertSame( 'First alt', $images[0]->alt );
+		$this->assertSame( '2026-05-31 09:08:07', $images[0]->date );
+		$this->assertSame( '', $images[1]->date, 'Invalid dates must not be passed into attachment creation.' );
+		$this->assertSame( 'https://example.test/wp-content/uploads/wppa/101.png', $images[0]->source_url );
+	}
+
+	public function test_tree_paths_global_order_and_random_fallback_are_deterministic(): void {
+		$plugin = new WpPhotoAlbumPlus();
+		$wpdb = $GLOBALS['wpdb'];
+		$wpdb->tables = array( 'wp_wppa_albums', 'wp_wppa_photos' );
+		$wpdb->albums = array(
+			$this->album( 20, 'Tree', '', 0, 1, 0 ),
+			$this->album( 21, 'Random', '', 0, 2, 3 ),
+		);
+		$wpdb->photos = array(
+			$this->photo( 12345, 20, 'webp', 'Zulu', '', 0 ),
+			$this->photo( 12346, 20, 'jpg', 'Alpha', '', 0 ),
+			$this->photo( 202, 21, 'jpg', 'B', '', 0 ),
+			$this->photo( 201, 21, 'jpg', 'A', '', 0 ),
+		);
+		$GLOBALS['foogallery_migrate_test_options']['wppa_file_system'] = 'tree';
+		$GLOBALS['foogallery_migrate_test_options']['wppa_list_photos_by'] = '-2';
+
+		$this->create_photo_file( '12/34/5.webp' );
+		$this->create_photo_file( '12/34/6.jpg' );
+		$this->create_photo_file( '20/1.jpg' );
+		$this->create_photo_file( '20/2.jpg' );
+
+		$galleries = $plugin->find_galleries();
+		$this->assertCount( 2, $galleries );
+
+		$tree_images = $plugin->load_object_children( $galleries[0] );
+		$this->assertSame( array( 12345, 12346 ), array_map( array( $this, 'object_id' ), $tree_images ) );
+		$this->assertSame( 'https://example.test/wp-content/uploads/wppa/12/34/5.webp', $tree_images[0]->source_url );
+
+		$random_images = $plugin->load_object_children( $galleries[1] );
+		$this->assertSame( array( 201, 202 ), array_map( array( $this, 'object_id' ), $random_images ) );
+	}
+
+	public function test_hierarchy_is_flattened_into_safe_album_to_gallery_candidates(): void {
+		$plugin = new WpPhotoAlbumPlus();
+		$wpdb = $GLOBALS['wpdb'];
+		$wpdb->tables = array( 'wp_wppa_albums', 'wp_wppa_photos' );
+		$wpdb->albums = array(
+			$this->album( 30, 'Parent', '', 0, 2, 1, -2 ),
+			$this->album( 31, 'Child', '', 30, 1, 1 ),
+			$this->album( 32, 'Grandchild', '', 31, 1, 1 ),
+			$this->album( 33, 'Zulu child', '', 30, 2, 1 ),
+		);
+		$wpdb->photos = array(
+			$this->photo( 301, 30, 'jpg', 'Parent photo', '', 1 ),
+			$this->photo( 311, 31, 'jpg', 'Child photo', '', 1 ),
+			$this->photo( 321, 32, 'jpg', 'Grandchild photo', '', 1 ),
+			$this->photo( 331, 33, 'jpg', 'Zulu photo', '', 1 ),
+		);
+		$this->create_photo_file( '301.jpg' );
+		$this->create_photo_file( '311.jpg' );
+		$this->create_photo_file( '321.jpg' );
+		$this->create_photo_file( '331.jpg' );
+
+		$albums = $plugin->find_albums();
+		$albums_by_id = array();
+		foreach ( $albums as $album ) {
+			$albums_by_id[ (int) $album->ID ] = $album;
+		}
+
+		$this->assertCount( 2, $albums );
+		$this->assertInstanceOf( Album::class, $albums_by_id[30] );
+		$this->assertSame( array( 30, 33, 31, 32 ), array_map( array( $this, 'object_id' ), $albums_by_id[30]->children ) );
+		$this->assertSame( array( 31, 32 ), array_map( array( $this, 'object_id' ), $albums_by_id[31]->children ) );
+		$this->assertContainsOnlyInstancesOf( Gallery::class, $albums_by_id[30]->children );
+	}
+
+	public function test_exact_numeric_shortcodes_and_blocks_match_while_dynamic_forms_remain_untouched(): void {
+		$plugin = new WpPhotoAlbumPlus();
+		$exact = array(
+			'[wppa type="album" album="42"]',
+			"[wppa type='slideonly' album='42']",
+			'[wppa album=42]',
+		);
+		$dynamic = array(
+			'[wppa]',
+			'[wppa type="album" album="#last"]',
+			'[wppa type="album" album="$Summer"]',
+			'[wppa type="album" album="42.43"]',
+			'[wppa type="album" album="42,43"]',
+			'[wppa type="album" album="42" album="#last"]',
+			'[wppa type="album" data-album="42"]',
+			'[wppa type="album" caption=\'album="42"\']',
+			'[wppa type="album" album="crypt-a1b2"]',
+			'[wppa type="album" album="#tags,summer"]',
+		);
+
+		foreach ( $exact as $shortcode ) {
+			$this->assertSame( 42, $this->extract_shortcode_id( $shortcode, $plugin ), $shortcode );
+			$this->assertSame( 'gallery', $plugin->get_content_object_type( $shortcode ) );
+		}
+		foreach ( $dynamic as $shortcode ) {
+			$this->assertFalse( $this->extract_shortcode_id( $shortcode, $plugin ), $shortcode );
+		}
+
+		$blocks = $plugin->get_block_patterns();
+		$this->assertArrayHasKey( 'wp-photo-album-plus/general', $blocks );
+		$this->assertArrayHasKey( 'wp-photo-album-plus/slideshow', $blocks );
+		$this->assertArrayHasKey( 'wppa/gutenberg-wppa', $blocks );
+
+		$exact_block = '<!-- wp:wp-photo-album-plus/general {"wppaAlbum":42,"wppaShortcode":"[wppa type=\\"slideonly\\" album=\\"42\\"]"} --><div>[wppa type="slideonly" album="42"]</div><!-- /wp:wp-photo-album-plus/general -->';
+		$dynamic_block = '<!-- wp:wp-photo-album-plus/general {"wppaAlbum":0,"wppaShortcode":"[wppa type=\\"slideonly\\" album=\\"#last\\"]"} --><div>[wppa type="slideonly" album="#last"]</div><!-- /wp:wp-photo-album-plus/general -->';
+		$this->assertSame( 42, $this->extract_shortcode_id( $exact_block, $plugin ) );
+		$this->assertFalse( $this->extract_shortcode_id( $dynamic_block, $plugin ) );
+		$this->assertSame(
+			42,
+			$plugin->get_content_block_identifier(
+				array(
+					'attrs' => array( 'wppaAlbum' => 42, 'wppaShortcode' => '[wppa type="slideonly" album="42"]' ),
+					'innerContent' => array(),
+				)
+			)
+		);
+		$this->assertFalse(
+			$plugin->get_content_block_identifier(
+				array(
+					'attrs' => array( 'id' => 99, 'wppaAlbum' => 0, 'wppaShortcode' => '[wppa type="slideonly" album="#last"]' ),
+					'innerContent' => array(),
+				)
+			)
+		);
+		$this->assertFalse(
+			$plugin->get_content_block_identifier(
+				array(
+					'attrs' => array( 'wppaShortcode' => '[wppa album="42"]' ),
+					'innerContent' => array( '<div>[wppa album="#last"]</div>' ),
+				)
+			)
+		);
+
+		$migrator = new ContentMigrator( new MigratorEngine(), 'content' );
+		$extract = new \ReflectionMethod( ContentMigrator::class, 'extract_gallery_id_from_block' );
+		$this->assertSame(
+			42,
+			$extract->invoke(
+				$migrator,
+				array( 'attrs' => array( 'wppaAlbum' => 42, 'wppaShortcode' => '[wppa type="slideonly" album="42"]' ) ),
+				$plugin
+			)
+		);
+		$this->assertFalse(
+			$extract->invoke(
+				$migrator,
+				array( 'attrs' => array( 'id' => 99, 'wppaAlbum' => 0, 'wppaShortcode' => '[wppa type="slideonly" album="#last"]' ) ),
+				$plugin
+			)
+		);
+	}
+
+	public function test_retry_discovery_reuses_migrated_gallery_instead_of_creating_duplicates(): void {
+		$plugin = new WpPhotoAlbumPlus();
+		$wpdb = $GLOBALS['wpdb'];
+		$wpdb->tables = array( 'wp_wppa_albums', 'wp_wppa_photos' );
+		$wpdb->albums = array( $this->album( 50, 'Retry', '', 0, 1, 1 ) );
+		$wpdb->photos = array( $this->photo( 501, 50, 'jpg', 'Only', '', 1 ) );
+		$this->create_photo_file( '501.jpg' );
+		$GLOBALS['foogallery_migrate_test_plugins'] = array( $plugin );
+		$GLOBALS['foogallery_migrate_test_attachment_url_to_postid']['https://example.test/wp-content/uploads/wppa/501.jpg'] = 4500;
+
+		$gallery = $plugin->find_galleries()[0];
+		$gallery->migrate();
+		$this->assertTrue( $gallery->migrated );
+		$this->assertCount( 0, $GLOBALS['foogallery_migrate_test_imported_attachments'] );
+		$post_count = count( $GLOBALS['foogallery_migrate_test_posts'] );
+
+		$retry = $plugin->find_galleries()[0];
+		$retry->migrate();
+		$this->assertTrue( $retry->migrated );
+		$this->assertSame( $gallery->migrated_id, $retry->migrated_id );
+		$this->assertSame( $post_count, count( $GLOBALS['foogallery_migrate_test_posts'] ) );
+		$this->assertCount( 0, $GLOBALS['foogallery_migrate_test_imported_attachments'] );
+	}
+
+	public function test_content_migrator_replaces_only_the_exact_numeric_shortcode(): void {
+		$plugin = new WpPhotoAlbumPlus();
+		$engine = $GLOBALS['foogallery_migrate_engine_instance'];
+		$exact = '[wppa type="album" album="42"]';
+		$dynamic = '[wppa type="album" album="#last"]';
+		$post = (object) array(
+			'ID'           => 700,
+			'post_title'   => 'WPPA content',
+			'post_content' => $exact . ' ' . $dynamic,
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+		);
+		$GLOBALS['foogallery_migrate_test_posts'][700] = $post;
+		$GLOBALS['wpdb']->content_posts = array( $post );
+		$plugin->is_detected = true;
+		$GLOBALS['foogallery_migrate_test_plugins'] = array( $plugin );
+		$engine->set_migrator_setting( MigratorEngine::KEY_PLUGINS, array( $plugin ) );
+
+		$gallery = $plugin->get_gallery(
+			array(
+				'ID'             => 42,
+				'title'          => 'Exact',
+				'data'           => null,
+				'children'       => array(),
+				'children_count' => 1,
+				'settings'       => array(),
+			)
+		);
+		$gallery->migrated = true;
+		$gallery->migrated_id = 9042;
+		$engine->add_migrated_object( $gallery );
+
+		$migrator = new ContentMigrator( $engine, 'content' );
+		$migrator->scan_content( true );
+		$get_items = new \ReflectionMethod( $migrator, 'get_content_items' );
+		$items = $get_items->invoke( $migrator );
+
+		$this->assertCount( 1, $items );
+		$this->assertSame( $exact, $items[0]['original_content'] );
+		$result = $migrator->replace_content( array( 0 ) );
+		$this->assertSame( 1, $result['success'] );
+		$this->assertSame( '[foogallery id="9042"] ' . $dynamic, $GLOBALS['foogallery_migrate_test_posts'][700]->post_content );
+
+		$exact_block = '<!-- wp:wp-photo-album-plus/general {"wppaShortcode":"[wppa album=\\"42\\"]"} --><div>[wppa album="42"]</div><!-- /wp:wp-photo-album-plus/general -->';
+		$mixed_block = '<!-- wp:wp-photo-album-plus/general {"wppaShortcode":"[wppa album=\\"42\\"]"} --><div>[wppa album="#last"]</div><!-- /wp:wp-photo-album-plus/general -->';
+		$post->post_content = $exact_block . "\nseparator\n" . $exact_block . "\n" . $mixed_block;
+		$GLOBALS['foogallery_migrate_test_posts'][700] = $post;
+		$GLOBALS['wpdb']->content_posts = array( $post );
+		$this->assertIsArray( $migrator->scan_content( true ) );
+		$items = $get_items->invoke( $migrator );
+		$this->assertCount( 2, $items, 'Only exact blocks should be candidates.' );
+		$keys = array_keys( $items );
+		$this->assertNotSame( $items[ $keys[0] ]['match_offset'], $items[ $keys[1] ]['match_offset'] );
+		$result = $migrator->replace_content( array( $keys[1] ) );
+		$this->assertSame( 1, $result['success'] );
+		$this->assertSame( 1, substr_count( $GLOBALS['foogallery_migrate_test_posts'][700]->post_content, $exact_block ) );
+		$this->assertStringContainsString( $mixed_block, $GLOBALS['foogallery_migrate_test_posts'][700]->post_content );
+	}
+
+	public function object_id( $object ): int {
+		return (int) $object->ID;
+	}
+
+	private function album( int $id, string $name, string $description, int $parent, int $order, int $photo_order, int $subalbum_order = 1 ): object {
+		return (object) array(
+			'id'            => $id,
+			'name'          => $name,
+			'description'   => $description,
+			'a_order'       => $order,
+			'a_parent'      => $parent,
+			'p_order_by'    => $photo_order,
+			'suba_order_by' => (string) $subalbum_order,
+			'timestamp'     => '2026-01-01 00:00:00',
+			'status'        => 'publish',
+			'capability'    => '',
+		);
+	}
+
+	private function photo( int $id, int $album, string $ext, string $name, string $description, int $order, string $status = 'publish', string $alt = '', string $timestamp = '2026-01-01 00:00:00' ): object {
+		return (object) array(
+			'id'           => $id,
+			'album'        => $album,
+			'ext'          => $ext,
+			'name'         => $name,
+			'description'  => $description,
+			'p_order'      => $order,
+			'owner'        => 'admin',
+			'timestamp'    => $timestamp,
+			'status'       => $status,
+			'alt'          => $alt,
+			'filename'     => $name . '.' . $ext,
+			'modified'     => $timestamp,
+			'exifdtm'      => '',
+			'mean_rating'  => '0',
+			'rating_count' => 0,
+			'videox'       => 0,
+			'videoy'       => 0,
+			'duration'     => '',
+			'misc'         => '',
+		);
+	}
+
+	private function create_photo_file( string $relative_path ): void {
+		$file = '/tmp/uploads/wppa/' . $relative_path;
+		$directory = dirname( $file );
+		if ( ! is_dir( $directory ) ) {
+			mkdir( $directory, 0777, true );
+		}
+		$fixtures = array(
+			'gif'  => 'R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==',
+			'jpg'  => '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAX/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAH/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAEFAqf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/Aaf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/Aaf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAY/Aqf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/Iaf/2gAMAwEAAgADAAAAEP/EABQRAQAAAAAAAAAAAAAAAAAAABD/2gAIAQMBAT8QH//EABQRAQAAAAAAAAAAAAAAAAAAABD/2gAIAQIBAT8QH//EABQQAQAAAAAAAAAAAAAAAAAAABD/2gAIAQEAAT8QH//Z',
+			'jpeg' => '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAX/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAH/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAEFAqf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/Aaf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/Aaf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAY/Aqf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/Iaf/2gAMAwEAAgADAAAAEP/EABQRAQAAAAAAAAAAAAAAAAAAABD/2gAIAQMBAT8QH//EABQRAQAAAAAAAAAAAAAAAAAAABD/2gAIAQIBAT8QH//EABQQAQAAAAAAAAAAAAAAAAAAABD/2gAIAQEAAT8QH//Z',
+			'png'  => 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+			'webp' => 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA',
+		);
+		$extension = strtolower( pathinfo( $file, PATHINFO_EXTENSION ) );
+		$data = isset( $fixtures[ $extension ] ) ? base64_decode( $fixtures[ $extension ] ) : 'synthetic non-image fixture';
+		file_put_contents( $file, $data );
+		$this->created_files[] = $file;
+	}
+
+	private function extract_shortcode_id( string $content, WpPhotoAlbumPlus $plugin ) {
+		$ids = array();
+		foreach ( $plugin->get_shortcode_patterns() as $pattern ) {
+			if ( ! preg_match_all( $pattern, $content, $all_matches, PREG_SET_ORDER ) ) {
+				continue;
+			}
+			foreach ( $all_matches as $matches ) {
+				if ( method_exists( $plugin, 'get_content_match_identifier' ) ) {
+					$id = $plugin->get_content_match_identifier( $matches );
+					if ( false !== $id ) {
+						$ids[ $id ] = true;
+					}
+					continue;
+				}
+				foreach ( array_slice( $matches, 1 ) as $match ) {
+					if ( is_numeric( $match ) ) {
+						$ids[ (int) $match ] = true;
+						break;
+					}
+				}
+			}
+		}
+
+		if ( 1 !== count( $ids ) ) {
+			return false;
+		}
+		$ids = array_keys( $ids );
+		return (int) reset( $ids );
+	}
+}
+
+class FakeWpPhotoAlbumPlusWpdb {
+	public $prefix = 'wp_';
+	public $base_prefix = 'wp_';
+	public $posts = 'wp_posts';
+	public $tables = array();
+	public $albums = array();
+	public $photos = array();
+	public $content_posts = array();
+	public $table_detection_arguments = array();
+	private $last_prepare_args = array();
+
+	public function esc_like( $text ) {
+		return addcslashes( $text, '_%\\' );
+	}
+
+	public function prepare( $query, ...$args ) {
+		if ( 1 === count( $args ) && is_array( $args[0] ) ) {
+			$args = $args[0];
+		}
+		$this->last_prepare_args = $args;
+		return $query;
+	}
+
+	public function get_var( $query ) {
+		if ( false !== stripos( $query, 'SHOW TABLES LIKE' ) ) {
+			$table = isset( $this->last_prepare_args[0] ) ? str_replace( array( '\\_', '\\%' ), array( '_', '%' ), $this->last_prepare_args[0] ) : '';
+			$this->table_detection_arguments[] = $table;
+			return in_array( $table, $this->tables, true ) ? $table : null;
+		}
+
+		return null;
+	}
+
+	public function get_results( $query, $output = null ) {
+		if ( false !== strpos( $query, 'FROM ' . $this->posts ) ) {
+			return $this->content_posts;
+		}
+		if ( false !== strpos( $query, 'wppa_albums' ) ) {
+			return $this->albums;
+		}
+		if ( false !== strpos( $query, 'wppa_photos' ) ) {
+			return $this->photos;
+		}
+		return array();
+	}
+}

--- a/tests/WpPhotoAlbumPlusPluginTest.php
+++ b/tests/WpPhotoAlbumPlusPluginTest.php
@@ -23,6 +23,7 @@ class WpPhotoAlbumPlusPluginTest extends TestCase {
 		$GLOBALS['foogallery_migrate_test_post_meta'] = array();
 		$GLOBALS['foogallery_migrate_test_imported_attachments'] = array();
 		$GLOBALS['foogallery_migrate_test_attachment_url_to_postid'] = array();
+		$_POST = array();
 		$GLOBALS['foogallery_migrate_engine_instance'] = new MigratorEngine();
 		$GLOBALS['wpdb'] = new FakeWpPhotoAlbumPlusWpdb();
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -509,8 +509,13 @@ function wp_remote_retrieve_response_code( $response ) {
 }
 
 function wp_get_upload_dir() {
+	$environment_basedir = getenv( 'FOOGALLERY_MIGRATE_TEST_UPLOAD_DIR' );
+	$basedir = isset( $GLOBALS['foogallery_migrate_test_upload_dir'] )
+		? $GLOBALS['foogallery_migrate_test_upload_dir']
+		: ( is_string( $environment_basedir ) && '' !== $environment_basedir ? $environment_basedir : '/tmp/uploads' );
+
 	return array(
-		'basedir' => '/tmp/uploads',
+		'basedir' => $basedir,
 		'baseurl' => 'https://example.test/wp-content/uploads',
 	);
 }


### PR DESCRIPTION
## Problem

FooGallery Migrate cannot currently discover or migrate WP Photo Album Plus data, especially when the source plugin is inactive. WPPA stores galleries in site-specific database tables and canonical image files outside the Media Library, with configurable ordering, visibility, hierarchy, and dynamic shortcode forms that require conservative handling.

## Approach

- Registers a source named exactly `WP Photo Album Plus`.
- Detects exact current-site WPPA album/photo tables while honoring active WPPA constants and avoiding LIKE wildcard false positives.
- Migrates only public, capability-unrestricted albums containing validated local JPG, JPEG, PNG, GIF, or runtime-inspectable WebP payloads.
- Supports canonical flat and tree WPPA upload layouts with path, symlink, traversal, extension, and payload validation.
- Preserves titles, captions/descriptions, alt text, valid dates, deterministic WPPA photo/subalbum ordering, and source IDs for idempotent retries.
- Maps nested source hierarchy to flattened FooGallery album candidates because FooGallery albums contain galleries rather than nested albums.
- Replaces only exact positive numeric WPPA shortcode/block album references. Dynamic, virtual, encrypted, combined, duplicate, prefixed, quoted-lookalike, mixed, and ambiguous forms remain unchanged.
- Retains raw block bytes and byte offsets so repeated identical block occurrences can be selected independently.

## Authoritative WPPA source

Implementation behavior was checked against the official WordPress.org WP Photo Album Plus stable release:

- Version: `9.2.10.004`
- Stable SVN tag: `tags/9.2.10.004`
- Tag revision: `r3647308`

## Tests and verification

- TDD RED captured before the implementation and for subsequent security/content-integrity regressions.
- Sabotage proof: weakening exact table detection made its focused test fail; the original implementation was restored and verified GREEN.
- `composer test`: 34 tests, 319 assertions, passed (PHP 8.5 emits three pre-existing ReflectionMethod deprecation notices from MigrationFlowTest).
- Focused WPPA suite: 10 tests, 72 assertions, passed independently.
- `php tests/content-scan-regression.php`: passed.
- `node tests/ajax-js-regression.js`: passed.
- `composer validate --strict`: passed.
- PHP syntax: all 41 repository PHP files passed `php -l`.
- PHP 5.4 compatibility parser: all touched production PHP files parsed successfully.
- `git diff --check`: passed.
- Independent fail-closed security/logic review: passed after fixing path/content validation, visibility, date, ordering, shortcode/block ambiguity, and exact block-occurrence findings.

## Risks and unsupported forms

- Video, audio, PDF, poster, missing, malformed, non-public, capability-restricted, and unknown-status payloads are skipped rather than imported as broken images.
- WebP requires image inspection support in the site's PHP runtime; otherwise it is skipped safely.
- Random or unknown source order falls back to stable source-ID order.
- Nested WPPA albums are flattened into gallery lists; unsupported/empty branches are omitted.
- Dynamic/virtual album expressions (`#...`, names, encrypted IDs, search/tag/query forms, combined IDs, and ambiguous duplicate/mixed forms) are intentionally left for manual review.
- No real WordPress integration environment was available in this worktree; verification used the repository's current develop PHPUnit/bootstrap and regression harnesses.

## Release safety

This PR does **not** deploy, merge, release, bump the plugin version/stable tag, or publish anything to WordPress.org SVN.
